### PR TITLE
Fix English evaluation language selection

### DIFF
--- a/chinatravel/agent/UrbanTrip/tpc_agent.py
+++ b/chinatravel/agent/UrbanTrip/tpc_agent.py
@@ -62,7 +62,7 @@ class UrbanTrip(BaseAgent):
         self.memory = {}
         self.TIME_CUT = 60 * 5 - 10
         self.debug = kwargs.get("debug", False)
-        self.poi_search = Poi()
+        self.poi_search = Poi(lang=kwargs.get("lang"))
 
         self.visited_attractions = set()
         self.visited_restaurants = set()

--- a/chinatravel/agent/UrbanTrip/utils.py
+++ b/chinatravel/agent/UrbanTrip/utils.py
@@ -84,7 +84,7 @@ def calc_cost_from_itinerary_wo_intercity(itinerary, people_number):
             # if activity["type"] == "train":
             #     total_cost += activity.get('tickets',0)*activity.get("cost", 0)
 
-            if activity["type"] == "breakfest" or activity["type"] == "lunch" or activity["type"] == "dinner":
+            if activity["type"] == "breakfast" or activity["type"] == "lunch" or activity["type"] == "dinner":
                 total_cost += activity.get('cost', 0) * people_number
 
             # if activity["type"] == "accommodation":

--- a/chinatravel/agent/nesy_agent/utils.py
+++ b/chinatravel/agent/nesy_agent/utils.py
@@ -66,7 +66,7 @@ def calc_cost_from_itinerary_wo_intercity(itinerary, people_number):
             # if activity["type"] == "train":
             #     total_cost += activity.get('tickets',0)*activity.get("cost", 0)
 
-            if activity["type"] == "breakfest" or activity["type"] == "lunch" or activity["type"] == "dinner":
+            if activity["type"] == "breakfast" or activity["type"] == "lunch" or activity["type"] == "dinner":
                 total_cost += activity.get('cost',0)*people_number
             
             # if activity["type"] == "accommodation":

--- a/chinatravel/evaluation/hard_constraint.py
+++ b/chinatravel/evaluation/hard_constraint.py
@@ -12,7 +12,13 @@ import os
 
 from chinatravel.evaluation.utils import load_json_file
 
-from chinatravel.symbol_verification.hard_constraint import get_symbolic_concepts, evaluate_constraints, evaluate_constraints_py
+from chinatravel.symbol_verification.hard_constraint import (
+    get_symbolic_concepts,
+    evaluate_constraints,
+    evaluate_constraints_py,
+    _infer_lang,
+    _set_tool_lang,
+)
 
 from tqdm import tqdm
 
@@ -25,7 +31,7 @@ import pandas as pd
 
 
 
-def evaluate_hard_constraints(data_index, symbolic_input_dict, plan_json_dict, verbose=False):
+def evaluate_hard_constraints(data_index, symbolic_input_dict, plan_json_dict, verbose=False, lang=None):
     
     result_agg = pd.DataFrame(columns=['data_id', 
                                         'Trip_Days', 'Trip_People', 
@@ -47,7 +53,8 @@ def evaluate_hard_constraints(data_index, symbolic_input_dict, plan_json_dict, v
     passed_id = []
 
     for ii, idx in enumerate(data_index):
-        symbolic_input, plan_json = symbolic_input_dict[idx], plan_json_dict[idx]  
+        symbolic_input, plan_json = symbolic_input_dict[idx], plan_json_dict[idx]
+        _set_tool_lang(lang or _infer_lang(symbolic_input))
         
         extracted_vars=get_symbolic_concepts(symbolic_input, plan_json, need_ood=False)
         
@@ -132,7 +139,7 @@ def evaluate_hard_constraints(data_index, symbolic_input_dict, plan_json_dict, v
     return macro*100, micro*100, result_agg, passed_id
 
 
-def evaluate_hard_constraints_v2(data_index, symbolic_input_dict, plan_json_dict, env_pass_id, verbose=False):
+def evaluate_hard_constraints_v2(data_index, symbolic_input_dict, plan_json_dict, env_pass_id, verbose=False, lang=None):
 
 
     max_logic_num = 0
@@ -156,7 +163,8 @@ def evaluate_hard_constraints_v2(data_index, symbolic_input_dict, plan_json_dict
     passed_id = []
 
     for ii, idx in enumerate(tqdm(data_index)):
-        symbolic_input, plan_json = symbolic_input_dict[idx], plan_json_dict[idx]  
+        symbolic_input, plan_json = symbolic_input_dict[idx], plan_json_dict[idx]
+        _set_tool_lang(lang or _infer_lang(symbolic_input))
         result_ii = evaluate_constraints_py(symbolic_input["hard_logic_py"], plan_json, verbose=verbose)
         results.append(result_ii)
 

--- a/chinatravel/symbol_verification/concept_func.py
+++ b/chinatravel/symbol_verification/concept_func.py
@@ -1,6 +1,33 @@
 from chinatravel.environment.tools.accommodations.apis import Accommodations
 from chinatravel.environment.tools.restaurants.apis import Restaurants
 from chinatravel.environment.tools.attractions.apis import Attractions
+from chinatravel.environment.language import CITY_NAMES, normalize_lang
+
+
+_current_lang = "zh"
+_TOOLS_BY_LANG = {}
+
+
+def _infer_lang_from_city(city):
+    if city in CITY_NAMES["en"]:
+        return "en"
+    return _current_lang
+
+
+def _tools_for_lang(lang=None):
+    lang = normalize_lang(lang or _current_lang)
+    if lang not in _TOOLS_BY_LANG:
+        _TOOLS_BY_LANG[lang] = {
+            "accommodations": Accommodations(lang=lang),
+            "restaurants": Restaurants(lang=lang),
+            "attractions": Attractions(lang=lang),
+        }
+    return _TOOLS_BY_LANG[lang]
+
+
+def set_concept_func_lang(lang=None):
+    global _current_lang
+    _current_lang = normalize_lang(lang)
 
 
 def day_count(plan):
@@ -85,7 +112,7 @@ def activity_time(activity):
 
 
 def poi_recommend_time(city, poi):
-    select = Attractions().select
+    select = _tools_for_lang(_infer_lang_from_city(city))["attractions"].select
     attrction_info = select(city, key="name", func=lambda x: x == poi).iloc[0]
     recommend_time = (attrction_info["recommendmintime"]) * 60
     return recommend_time
@@ -94,7 +121,7 @@ def poi_recommend_time(city, poi):
 def poi_distance(city, poi1, poi2, start_time="00:00", transport_type="walk"):
     from chinatravel.environment.tools.transportation.apis import Transportation
 
-    goto = Transportation().goto
+    goto = Transportation(lang=_infer_lang_from_city(city)).goto
     return goto(city, poi1, poi2, start_time, transport_type)[0]["distance"]
 
 
@@ -170,9 +197,7 @@ def room_type(activity):
 
 
 def restaurant_type(activity, target_city):
-    from chinatravel.environment.tools.restaurants.apis import Restaurants
-
-    restaurants = Restaurants()
+    restaurants = _tools_for_lang(_infer_lang_from_city(target_city))["restaurants"]
     select_food_type = restaurants.select(
         target_city, key="name", func=lambda x: x == activity["position"]
     )["cuisine"]
@@ -182,9 +207,7 @@ def restaurant_type(activity, target_city):
 
 
 def attraction_type(activity, target_city):
-    from chinatravel.environment.tools.attractions.apis import Attractions
-
-    attractions = Attractions()
+    attractions = _tools_for_lang(_infer_lang_from_city(target_city))["attractions"]
     select_attr_type = attractions.select(
         target_city, key="name", func=lambda x: x == activity["position"]
     )["type"]
@@ -194,9 +217,7 @@ def attraction_type(activity, target_city):
 
 
 def accommodation_type(activity, target_city):
-    from chinatravel.environment.tools.accommodations.apis import Accommodations
-
-    accommodations = Accommodations()
+    accommodations = _tools_for_lang(_infer_lang_from_city(target_city))["accommodations"]
     select_hotel_type = accommodations.select(
         target_city, key="name", func=lambda x: x == activity["position"]
     )["featurehoteltype"]

--- a/chinatravel/symbol_verification/hard_constraint.py
+++ b/chinatravel/symbol_verification/hard_constraint.py
@@ -6,8 +6,9 @@ from chinatravel.environment.tools.restaurants.apis import Restaurants
 from chinatravel.environment.tools.attractions.apis import Attractions
 from chinatravel.environment.tools.intercity_transport.apis import IntercityTransport
 from chinatravel.environment.tools.transportation.apis import Transportation
+from chinatravel.environment.language import CITY_NAMES, normalize_lang
 
-from chinatravel.symbol_verification.concept_func import func_dict
+from chinatravel.symbol_verification.concept_func import func_dict, set_concept_func_lang
 from chinatravel.evaluation.utils import load_json_file
 
 import pandas as pd
@@ -17,6 +18,32 @@ from copy import deepcopy
 accommodation = Accommodations()
 restaurants = Restaurants()
 attractions = Attractions()
+_TOOLS_BY_LANG = {
+    "zh": (accommodation, restaurants, attractions)
+}
+
+
+def _infer_lang(symbolic_input):
+    city_values = {
+        symbolic_input.get("start_city"),
+        symbolic_input.get("target_city"),
+    }
+    if city_values & set(CITY_NAMES["en"]):
+        return "en"
+    return "zh"
+
+
+def _set_tool_lang(lang):
+    global accommodation, restaurants, attractions
+    lang = normalize_lang(lang)
+    if lang not in _TOOLS_BY_LANG:
+        _TOOLS_BY_LANG[lang] = (
+            Accommodations(lang=lang),
+            Restaurants(lang=lang),
+            Attractions(lang=lang),
+        )
+    accommodation, restaurants, attractions = _TOOLS_BY_LANG[lang]
+    set_concept_func_lang(lang)
 
 
 def calc_cost_from_itinerary_wo_intercity(itinerary, people_number):
@@ -40,7 +67,7 @@ def calc_cost_from_itinerary_wo_intercity(itinerary, people_number):
                     total_cost += transport.get("tickets", 0) * transport.get("cost", 0)
 
             if (
-                activity["type"] == "breakfest"
+                activity["type"] == "breakfast"
                 or activity["type"] == "lunch"
                 or activity["type"] == "dinner"
             ):
@@ -180,7 +207,7 @@ def get_symbolic_concepts(symbolic_input, plan_json, need_ood=False):
                 continue
 
             if (
-                activity["type"] == "breakfest"
+                activity["type"] == "breakfast"
                 or activity["type"] == "lunch"
                 or activity["type"] == "dinner"
             ):
@@ -269,7 +296,7 @@ def get_symbolic_concepts(symbolic_input, plan_json, need_ood=False):
             if activity["type"] == "attraction":
                 cost_attraction += activity.get("tickets", 0) * activity.get("cost", 0)
             if activity["type"] == "airplane" or activity["type"] == "train":
-                if "cost" in activity and "ticket" in activity:
+                if "cost" in activity and "tickets" in activity:
                     cost_intercity_transport += activity.get(
                         "tickets", 0
                     ) * activity.get("cost", 0)

--- a/chinatravel/symbol_verification/hard_constraint.py
+++ b/chinatravel/symbol_verification/hard_constraint.py
@@ -291,7 +291,7 @@ def get_symbolic_concepts(symbolic_input, plan_json, need_ood=False):
     cost_intercity_transport_missing = False
     for day in plan_json["itinerary"]:
         for activity in day["activities"]:
-            if not type in activity:
+            if "type" not in activity:
                 continue
             if activity["type"] == "attraction":
                 cost_attraction += activity.get("tickets", 0) * activity.get("cost", 0)

--- a/eval_exp.py
+++ b/eval_exp.py
@@ -129,7 +129,7 @@ if __name__ == "__main__":
         print("Schema Pass Rate:", schema_rate)
 
         macro_comm, micro_comm, common_result_agg, commonsense_pass_id = evaluate_commonsense_constraints(
-            query_index, query_data, result_data[method], verbose=False
+            query_index, query_data, result_data[method], verbose=False, lang=args.lang
         )
 
         res_file = "eval_res/splits_{}/{}/commonsense.csv".format(args.splits, method)
@@ -155,7 +155,7 @@ if __name__ == "__main__":
 
         print("Logical constraints (python version):")
         macro_logi, micro_logi, conditional_macro_logi, conditional_micro_logi, logi_result_agg, logi_pass_id = evaluate_hard_constraints_v2(
-            query_index, query_data, result_data[method], env_pass_id=commonsense_pass_id, verbose=False
+            query_index, query_data, result_data[method], env_pass_id=commonsense_pass_id, verbose=False, lang=args.lang
         )
 
 

--- a/eval_tpc.py
+++ b/eval_tpc.py
@@ -195,7 +195,7 @@ if __name__ == "__main__":
 
         # print("Logical constraints (python version):")
         macro_logi, micro_logi, conditional_macro_logi, conditional_micro_logi, logi_result_agg, logi_pass_id = evaluate_hard_constraints_v2(
-            query_index, query_data, result_data[method], env_pass_id=commonsense_pass_id, verbose=False
+            query_index, query_data, result_data[method], env_pass_id=commonsense_pass_id, verbose=False, lang=args.lang
         )
 
 


### PR DESCRIPTION
## Summary
- Pass evaluation language through commonsense and hard-constraint evaluation paths.
- Ensure hard-constraint DSL helper functions query the English database when evaluating English plans.
- Fix UrbanTrip English POI lookup and breakfast/tickets typos that affected constraint/cost calculation.

## Validation
- `py_compile` for updated evaluation, hard-constraint, concept helper, and UrbanTrip files.
- Ran UrbanTrip on 10 English phase1 samples: all 10 generated successfully.
- Evaluated `urbantrip_probe10` with English mode: `MicEPR=100`, `MacEPR=100`, `C-LPR=100`, `FPR=100`, `overall=96.3783233266316`.