### PR TITLE
[codex] Fix hard logic quote normalization

### DIFF
--- a/chinatravel/symbol_verification/hard_constraint.py
+++ b/chinatravel/symbol_verification/hard_constraint.py
@@ -1,5 +1,7 @@
 import sys
 import os
+import json
+import re
 
 from chinatravel.environment.tools.accommodations.apis import Accommodations
 from chinatravel.environment.tools.restaurants.apis import Restaurants
@@ -48,6 +50,41 @@ def _set_tool_lang(lang):
         )
     accommodation, restaurants, attractions = _TOOLS_BY_LANG[lang]
     set_concept_func_lang(lang)
+
+
+_ACTIVITY_POSITION_EQ_RE = re.compile(
+    r"^(?P<prefix>\s*if\s+activity_position\(activity\)\s*==\s*)'"
+    r"(?P<value>.*)'(?P<suffix>\s*:\s*)$",
+    re.MULTILINE,
+)
+_POI_DISTANCE_TARGET_RE = re.compile(
+    r"poi_distance\((?P<prefix>\s*target_city\(plan\)\s*,\s*)'"
+    r"(?P<value>[^\n]*)'(?P<suffix>\s*,\s*accommodation_position\s*\))"
+)
+
+
+def _normalize_legacy_hard_logic_py(constraint):
+    """Rewrite generated POI string literals that were emitted with single quotes."""
+    if not isinstance(constraint, str):
+        return constraint
+
+    def replace_activity_position(match):
+        return (
+            f"{match.group('prefix')}"
+            f"{json.dumps(match.group('value'), ensure_ascii=False)}"
+            f"{match.group('suffix')}"
+        )
+
+    def replace_poi_distance(match):
+        return (
+            "poi_distance("
+            f"{match.group('prefix')}"
+            f"{json.dumps(match.group('value'), ensure_ascii=False)}"
+            f"{match.group('suffix')}"
+        )
+
+    constraint = _ACTIVITY_POSITION_EQ_RE.sub(replace_activity_position, constraint)
+    return _POI_DISTANCE_TARGET_RE.sub(replace_poi_distance, constraint)
 
 
 def calc_cost_from_itinerary_wo_intercity(itinerary, people_number):
@@ -448,7 +485,9 @@ for activity in allactivities(plan):
 """
     # hard_logic_py.append(debug_logic_py)
     for constraint in hard_logic_py:
+        original_constraint = constraint
         constraint = normalize_concept_constraint_source(constraint)
+        constraint = _normalize_legacy_hard_logic_py(constraint)
         vars_dict = deepcopy(func_dict)
         vars_dict["plan"] = plan
         # exec(constraint, {"__builtins__": {"set": set, "print": print}}, vars_dict)
@@ -471,7 +510,7 @@ for activity in allactivities(plan):
             # results.append(result)
         except Exception as e:
             if verbose:
-                print(f"Error evaluating constraint '{constraint}': {e}")
+                print(f"Error evaluating constraint '{original_constraint}': {e}")
             results.append(False)
         # print(results)
     return results


### PR DESCRIPTION
## Summary

This fixes hard constraint evaluation for legacy/generated `hard_logic_py` snippets that embed POI names in single-quoted Python string literals.

Some English POI names contain ASCII apostrophes, for example `People's Square` or `Peppa Pig's World of Fun`. When those names are emitted as `'...'`, the verifier hits a `SyntaxError` before evaluating the constraint. The patch normalizes the generated POI string literal contexts before `exec`:

- `activity_position(activity)=='...'`
- `poi_distance(target_city(plan), '...', accommodation_position)`

The normalized value is emitted with `json.dumps(..., ensure_ascii=False)`, so the string literal is valid Python while preserving the original POI text.

## Validation

- `python -m py_compile chinatravel/symbol_verification/hard_constraint.py`
- Targeted evaluator check for a legacy apostrophe-containing `activity_position` constraint
- Local phase1 audit: all 13 previously recorded legacy snippets normalize and compile successfully

The local phase1 data/log files used for diagnosis are intentionally not included in this PR.