### PR TITLE
[codex] Fix evaluator entity grounding

### DIFF
--- a/chinatravel/evaluation/commonsense_constraint.py
+++ b/chinatravel/evaluation/commonsense_constraint.py
@@ -23,6 +23,7 @@ import pandas as pd
 # innercity_transport=Transportation()
 
 from chinatravel.symbol_verification.commonsense_constraint import (
+    Is_activity_grounded,
     Is_intercity_transport_correct,
     Is_attractions_correct,
     Is_hotels_correct,
@@ -51,7 +52,7 @@ Available
 def evaluate_commonsense_constraints(data_index, symbolic_input_dict, plan_json_dict, verbose=False, lang=None):
     # assert len(symbolic_input_list)==len(plan_json_list)
 
-    func_list = [Is_intercity_transport_correct, Is_attractions_correct, Is_hotels_correct, Is_restaurants_correct, Is_transport_correct, Is_time_correct, Is_space_correct]
+    func_list = [Is_activity_grounded, Is_intercity_transport_correct, Is_attractions_correct, Is_hotels_correct, Is_restaurants_correct, Is_transport_correct, Is_time_correct, Is_space_correct]
     total_correct = 0
 
     individual_results = []

--- a/chinatravel/evaluation/output_schema.json
+++ b/chinatravel/evaluation/output_schema.json
@@ -128,10 +128,33 @@
                       "type": {
                         "enum": ["airplane", "train"]
                       }
-                    }
+                    },
+                    "required": ["type"]
                   },
                   "then": {
-                    "required": ["start", "end"]
+                    "required": ["start", "end"],
+                    "not": {
+                      "required": ["position"]
+                    }
+                  },
+                  "else": {
+                    "required": ["position"],
+                    "not": {
+                      "anyOf": [
+                        {
+                          "required": ["start"]
+                        },
+                        {
+                          "required": ["end"]
+                        },
+                        {
+                          "required": ["FlightID"]
+                        },
+                        {
+                          "required": ["TrainID"]
+                        }
+                      ]
+                    }
                   }
                 },
                 {

--- a/chinatravel/symbol_verification/commonsense_constraint.py
+++ b/chinatravel/symbol_verification/commonsense_constraint.py
@@ -7,6 +7,7 @@ from chinatravel.environment.tools.attractions.apis import Attractions
 from chinatravel.environment.tools.intercity_transport.apis import IntercityTransport
 from chinatravel.environment.tools.transportation.apis import Transportation
 from chinatravel.environment.language import CITY_NAMES, normalize_lang
+from chinatravel.symbol_verification.concept_func import normalize_poi_name
 
 # from env.tools.transportation.apis import GoTo
 # from envs import goto
@@ -502,7 +503,8 @@ def Is_attractions_correct(symbolic_input, plan_json, verbose=False):
                 error_info.append("No position information!")
                 return table_statistics, error_info
             
-            select_attraction=attractions.select(target_city,key='name',func=lambda x:x==activity_i["position"])
+            position = normalize_poi_name(activity_i["position"])
+            select_attraction=attractions.select(target_city,key='name',func=lambda x:x==position)
 
             # print(select_attraction)
 
@@ -512,7 +514,7 @@ def Is_attractions_correct(symbolic_input, plan_json, verbose=False):
                 return table_statistics, error_info
 
             else:
-                attraction_list.append(activity_i["position"])
+                attraction_list.append(position)
             
             # 开放时间
             opentime, endtime = select_attraction["opentime"].values[0],  select_attraction["endtime"].values[0]
@@ -608,7 +610,8 @@ def Is_hotels_correct(symbolic_input, plan_json, verbose=False):
                 error_info.append("No position information!")
                 return table_statistics, error_info
             
-            select_hotel=accommodation.select(target_city,key='name',func=lambda x:x==activity_i["position"])
+            position = normalize_poi_name(activity_i["position"])
+            select_hotel=accommodation.select(target_city,key='name',func=lambda x:x==position)
             # print(select_hotel)
 
             if select_hotel.empty:
@@ -617,7 +620,7 @@ def Is_hotels_correct(symbolic_input, plan_json, verbose=False):
                 return table_statistics, error_info
 
             else:
-                hotel_list.append(activity_i["position"])
+                hotel_list.append(position)
 
             # 返回信息保证一致: price
             try: 
@@ -703,13 +706,14 @@ def Is_restaurants_correct(symbolic_input, plan_json, verbose=False):
                 return table_statistics, error_info
             
 
-            select_restaurant=restaurants.select(target_city,key='name',func=lambda x:x==activity_i["position"])
+            position = normalize_poi_name(activity_i["position"])
+            select_restaurant=restaurants.select(target_city,key='name',func=lambda x:x==position)
 
             # print(select_restaurant)
 
             if activity_i["type"] == "breakfast" and select_restaurant.empty:
 
-                select_hotel=accommodation.select(target_city,key='name',func=lambda x:x==activity_i["position"])
+                select_hotel=accommodation.select(target_city,key='name',func=lambda x:x==position)
     
                 if select_hotel.empty:
                     table_statistics.loc[0] = [1, 1, 1, 1, 1, 1]
@@ -798,7 +802,7 @@ def Is_restaurants_correct(symbolic_input, plan_json, verbose=False):
             except:
                 table_statistics.loc[0,  'Visiting Restruants in their closed time'] = 1
                 error_info.append("Schedule of Restruants should be provided")
-            restaurants_list.append(activity_i["position"])
+            restaurants_list.append(position)
             # restaurants_time_list.append(activity_i["start_time"])
 
     if len(set(restaurants_list)) != len(restaurants_list):
@@ -855,8 +859,8 @@ def Is_transport_correct(symbolic_input, plan_json, verbose=False):
                     table_statistics.loc[0] = [1, 1, 1]
                     error_info.append("Key Error: [start, end, start_time, end_time]")
                 
-                source_poi = transport_i[0]["start"]
-                target_poi = transport_i[-1]["end"]
+                source_poi = normalize_poi_name(transport_i[0]["start"])
+                target_poi = normalize_poi_name(transport_i[-1]["end"])
                 start_time = transport_i[0]["start_time"]
 
                 # print(transport_i)
@@ -878,11 +882,11 @@ def Is_transport_correct(symbolic_input, plan_json, verbose=False):
                     for idx, trans_ii in enumerate(transport_i):
                         
                         try:
-                            if trans_ii["start"] != tools_return[idx]["start"]:
+                            if normalize_poi_name(trans_ii["start"]) != normalize_poi_name(tools_return[idx]["start"]):
                                 table_statistics.loc[0,  'Unavailable Inner-City Transport'] = 1
                                 error_info.append("Incorrect infomation of transport {} -> {}".format(source_poi, target_poi) + "  [{}], Tool: [{}]".format(trans_ii, tools_return[idx]))
                         
-                            if trans_ii["end"] != tools_return[idx]["end"]:
+                            if normalize_poi_name(trans_ii["end"]) != normalize_poi_name(tools_return[idx]["end"]):
                                 table_statistics.loc[0,  'Unavailable Inner-City Transport'] = 1
                                 error_info.append("Incorrect infomation of transport {} -> {}".format(source_poi, target_poi) + "  [{}], Tool: [{}]".format(trans_ii, tools_return[idx]))
                         except:
@@ -959,11 +963,11 @@ def Is_transport_correct(symbolic_input, plan_json, verbose=False):
                         continue
                     for idx, trans_ii in enumerate(transport_i):
                         try:
-                            if trans_ii["start"] != tools_return[idx]["start"]:
+                            if normalize_poi_name(trans_ii["start"]) != normalize_poi_name(tools_return[idx]["start"]):
                                 table_statistics.loc[0,  'Unavailable Inner-City Transport'] = 1
                                 error_info.append("Incorrect infomation of transport {} -> {}".format(source_poi, target_poi) + "  [{}], Tool: [{}]".format(trans_ii, tools_return[idx]))
                         
-                            if trans_ii["end"] != tools_return[idx]["end"]:
+                            if normalize_poi_name(trans_ii["end"]) != normalize_poi_name(tools_return[idx]["end"]):
                                 table_statistics.loc[0,  'Unavailable Inner-City Transport'] = 1
                                 error_info.append("Incorrect infomation of transport {} -> {}".format(source_poi, target_poi) + "  [{}], Tool: [{}]".format(trans_ii, tools_return[idx]))
                         except:
@@ -1143,14 +1147,14 @@ def Is_space_correct(symbolic_input, plan_json, verbose=False):
                     error_info.append("Only intercity transport may omit position: " + str(activity_i))
                     continue
                 if "start" in activity_i and "end" in activity_i:
-                    current_position = activity_i["start"]
+                    current_position = normalize_poi_name(activity_i["start"])
                 else:
                     table_statistics.loc[0, 'Invalid Transport information across positions'] = 1
                     error_info.append("Every activity need a position or start/end keys: " + str(activity_i))
                     continue
 
             else:
-                current_position = activity_i["position"]
+                current_position = normalize_poi_name(activity_i["position"])
 
             if not "transports" in activity_i:
                 # print(activity_i)
@@ -1176,22 +1180,22 @@ def Is_space_correct(symbolic_input, plan_json, verbose=False):
                     # continue
 
                 else:
-                    if activity_i["transports"][0]["start"] != position_list[-1]:
+                    if normalize_poi_name(activity_i["transports"][0]["start"]) != position_list[-1]:
 
                         table_statistics.loc[0, 'Invalid Transport information across positions'] = 1
                         error_info.append("The origin of the transport must be equal to the position of the previous activity.: " + str(activity_i))
                         # continue
 
-                    if activity_i["transports"][-1]["end"] != position_i:
+                    if normalize_poi_name(activity_i["transports"][-1]["end"]) != position_i:
 
                         table_statistics.loc[0, 'Invalid Transport information across positions'] = 1
                         error_info.append("The destination of the transport must be equal to the position of the current activity.: " + str(activity_i))
                         # continue
 
             if "position" in activity_i:
-                position_list.append(activity_i["position"])
+                position_list.append(normalize_poi_name(activity_i["position"]))
             else:
-                position_list.append(activity_i["end"])
+                position_list.append(normalize_poi_name(activity_i["end"]))
 
     # print("position_list: ", position_list)
 

--- a/chinatravel/symbol_verification/commonsense_constraint.py
+++ b/chinatravel/symbol_verification/commonsense_constraint.py
@@ -77,12 +77,105 @@ Available
 7. space
 '''
 
+_INTERCITY_ACTIVITY_TYPES = {"airplane", "train"}
+_POSITION_ACTIVITY_TYPES = {"attraction", "breakfast", "lunch", "dinner", "accommodation"}
+
+
 def return_info_debug(flag, info):
     return flag, info
 
 
 def return_info_test(flag, info):
     return flag
+
+
+def Is_activity_grounded(symbolic_input, plan_json, verbose=False):
+    
+    table_statistics = pd.DataFrame(columns=['Invalid or ungrounded activity entity'])
+
+    error_info = []
+
+    if not isinstance(plan_json, dict):
+        table_statistics.loc[0] = [1]
+        error_info = ["Error plan type, must be python dict"]
+        return table_statistics, error_info
+    try:
+        plan = plan_json["itinerary"]
+    except:
+        table_statistics.loc[0] = [1]
+        error_info = ["Error plan type, must provide itinerary"]
+        return table_statistics, error_info
+
+    table_statistics.loc[0] = [0]
+
+    if not isinstance(plan, list) or len(plan) == 0:
+        table_statistics.loc[0, 'Invalid or ungrounded activity entity'] = 1
+        error_info.append("Itinerary must be a non-empty list.")
+        return table_statistics, error_info
+
+    last_day_idx = len(plan) - 1
+    for day_idx, day_plan_i in enumerate(plan):
+        activities = day_plan_i.get("activities", []) if isinstance(day_plan_i, dict) else []
+        if not isinstance(activities, list):
+            table_statistics.loc[0, 'Invalid or ungrounded activity entity'] = 1
+            error_info.append("Each itinerary day must provide an activities list.")
+            continue
+
+        last_activity_idx = len(activities) - 1
+        for activity_idx, activity_i in enumerate(activities):
+            if not isinstance(activity_i, dict):
+                table_statistics.loc[0, 'Invalid or ungrounded activity entity'] = 1
+                error_info.append("Each activity must be a dict.")
+                continue
+
+            activity_type = activity_i.get("type")
+            is_first_activity = day_idx == 0 and activity_idx == 0
+            is_last_activity = day_idx == last_day_idx and activity_idx == last_activity_idx
+
+            if activity_type in _INTERCITY_ACTIVITY_TYPES:
+                if not (is_first_activity or is_last_activity):
+                    table_statistics.loc[0, 'Invalid or ungrounded activity entity'] = 1
+                    error_info.append("Intercity transport can only appear as the first or last activity: " + str(activity_i))
+
+                if activity_i.get("position"):
+                    table_statistics.loc[0, 'Invalid or ungrounded activity entity'] = 1
+                    error_info.append("Intercity transport must not provide a POI position: " + str(activity_i))
+
+                required_id = "FlightID" if activity_type == "airplane" else "TrainID"
+                forbidden_id = "TrainID" if activity_type == "airplane" else "FlightID"
+                if required_id not in activity_i:
+                    table_statistics.loc[0, 'Invalid or ungrounded activity entity'] = 1
+                    error_info.append("Intercity transport misses {}: ".format(required_id) + str(activity_i))
+                if forbidden_id in activity_i:
+                    table_statistics.loc[0, 'Invalid or ungrounded activity entity'] = 1
+                    error_info.append("Intercity transport has mismatched id field {}: ".format(forbidden_id) + str(activity_i))
+                if "start" not in activity_i or "end" not in activity_i:
+                    table_statistics.loc[0, 'Invalid or ungrounded activity entity'] = 1
+                    error_info.append("Intercity transport must provide start and end: " + str(activity_i))
+                continue
+
+            if activity_type not in _POSITION_ACTIVITY_TYPES:
+                table_statistics.loc[0, 'Invalid or ungrounded activity entity'] = 1
+                error_info.append("Unknown activity type: " + str(activity_i))
+                continue
+
+            if not activity_i.get("position"):
+                table_statistics.loc[0, 'Invalid or ungrounded activity entity'] = 1
+                error_info.append("POI activity must provide a position: " + str(activity_i))
+
+            forbidden_keys = [key for key in ("start", "end", "TrainID", "FlightID") if key in activity_i]
+            if forbidden_keys:
+                table_statistics.loc[0, 'Invalid or ungrounded activity entity'] = 1
+                error_info.append("POI activity must not provide intercity fields {}: ".format(forbidden_keys) + str(activity_i))
+
+    if verbose:
+        if table_statistics.loc[0].sum() == 0:
+            print("Activity grounding passed!")
+        else:
+            print(error_info)
+            print(table_statistics)
+    return table_statistics, error_info
+
 
 
 def Is_intercity_transport_correct(symbolic_input, plan_json, verbose=False):
@@ -1030,16 +1123,30 @@ def Is_space_correct(symbolic_input, plan_json, verbose=False):
     plan = plan_json["itinerary"]
 
     position_list = []
+    last_day_idx = len(plan) - 1
 
-    for day_plan_i in plan:
-        for activity_i in day_plan_i["activities"]:
+    for day_idx, day_plan_i in enumerate(plan):
+        activities = day_plan_i["activities"]
+        last_activity_idx = len(activities) - 1
+        for activity_idx, activity_i in enumerate(activities):
+            
+            activity_type = activity_i.get("type")
+            is_first_activity = day_idx == 0 and activity_idx == 0
+            is_last_activity = day_idx == last_day_idx and activity_idx == last_activity_idx
+            if activity_type in _INTERCITY_ACTIVITY_TYPES and not (is_first_activity or is_last_activity):
+                table_statistics.loc[0, 'Invalid Transport information across positions'] = 1
+                error_info.append("Intercity transport can only appear as the first or last activity: " + str(activity_i))
 
             if not "position" in activity_i:
-                if "start" in activity_i:
+                if activity_type not in _INTERCITY_ACTIVITY_TYPES:
+                    table_statistics.loc[0, 'Invalid Transport information across positions'] = 1
+                    error_info.append("Only intercity transport may omit position: " + str(activity_i))
+                    continue
+                if "start" in activity_i and "end" in activity_i:
                     current_position = activity_i["start"]
                 else:
                     table_statistics.loc[0, 'Invalid Transport information across positions'] = 1
-                    error_info.append("Every activity need a position key: ".format(activity_i))
+                    error_info.append("Every activity need a position or start/end keys: " + str(activity_i))
                     continue
 
             else:
@@ -1100,7 +1207,7 @@ def Is_space_correct(symbolic_input, plan_json, verbose=False):
 def func_commonsense_constraints(symbolic_input, plan_json, verbose=False, lang=None):
     _set_tool_lang(lang or _infer_lang(symbolic_input))
 
-    func_list = [Is_intercity_transport_correct, Is_attractions_correct, Is_hotels_correct, Is_restaurants_correct, Is_transport_correct, Is_time_correct, Is_space_correct]
+    func_list = [Is_activity_grounded, Is_intercity_transport_correct, Is_attractions_correct, Is_hotels_correct, Is_restaurants_correct, Is_transport_correct, Is_time_correct, Is_space_correct]
     succ_flag = True
     error_list = []
     for func in func_list:
@@ -1125,7 +1232,7 @@ def func_commonsense_constraints(symbolic_input, plan_json, verbose=False, lang=
 def evaluate_commonsense_constraints(data_index, symbolic_input_dict, plan_json_dict, verbose=False):
     # assert len(symbolic_input_list)==len(plan_json_list)
 
-    func_list = [Is_intercity_transport_correct, Is_attractions_correct, Is_hotels_correct, Is_restaurants_correct, Is_transport_correct, Is_time_correct, Is_space_correct]
+    func_list = [Is_activity_grounded, Is_intercity_transport_correct, Is_attractions_correct, Is_hotels_correct, Is_restaurants_correct, Is_transport_correct, Is_time_correct, Is_space_correct]
     total_correct = 0
 
     individual_results = []

--- a/chinatravel/symbol_verification/concept_func.py
+++ b/chinatravel/symbol_verification/concept_func.py
@@ -126,6 +126,8 @@ def dayactivities(plan, day):
 
 
 def activity_position(activity):
+    if activity.get("type") in {"airplane", "train"}:
+        return ""
     return activity.get("position", "")
 
 

--- a/chinatravel/symbol_verification/concept_func.py
+++ b/chinatravel/symbol_verification/concept_func.py
@@ -47,6 +47,9 @@ _CONCEPT_LITERAL_ALIASES = {
     for aliases in _CONCEPT_VALUE_ALIASES.values()
     for alias, canonical in aliases.items()
 }
+_POI_NAME_ALIASES = {
+    "Bistro Sola": "Sola Bistro",
+}
 
 
 def _infer_lang_from_city(city):
@@ -77,11 +80,17 @@ def normalize_concept_value(kind, value):
     return _CONCEPT_VALUE_ALIASES.get(kind, {}).get(value, value)
 
 
+def normalize_poi_name(value):
+    if not isinstance(value, str):
+        return value
+    return _POI_NAME_ALIASES.get(value, value)
+
+
 def normalize_concept_constraint_source(source):
     if not isinstance(source, str):
         return source
     normalized = source
-    for alias, canonical in _CONCEPT_LITERAL_ALIASES.items():
+    for alias, canonical in {**_CONCEPT_LITERAL_ALIASES, **_POI_NAME_ALIASES}.items():
         for quote in ("'", '"'):
             normalized = normalized.replace(
                 f"{quote}{alias}{quote}", f"{quote}{canonical}{quote}"
@@ -128,7 +137,7 @@ def dayactivities(plan, day):
 def activity_position(activity):
     if activity.get("type") in {"airplane", "train"}:
         return ""
-    return activity.get("position", "")
+    return normalize_poi_name(activity.get("position", ""))
 
 
 def activity_cost(activity):
@@ -259,8 +268,9 @@ def room_type(activity):
 
 def restaurant_type(activity, target_city):
     restaurants = _tools_for_lang(_infer_lang_from_city(target_city))["restaurants"]
+    position = normalize_poi_name(activity["position"])
     select_food_type = restaurants.select(
-        target_city, key="name", func=lambda x: x == activity["position"]
+        target_city, key="name", func=lambda x: x == position
     )["cuisine"]
     if not select_food_type.empty:
         return normalize_concept_value("restaurant", select_food_type.iloc[0])
@@ -269,8 +279,9 @@ def restaurant_type(activity, target_city):
 
 def attraction_type(activity, target_city):
     attractions = _tools_for_lang(_infer_lang_from_city(target_city))["attractions"]
+    position = normalize_poi_name(activity["position"])
     select_attr_type = attractions.select(
-        target_city, key="name", func=lambda x: x == activity["position"]
+        target_city, key="name", func=lambda x: x == position
     )["type"]
     if not select_attr_type.empty:
         return normalize_concept_value("attraction", select_attr_type.iloc[0])
@@ -279,8 +290,9 @@ def attraction_type(activity, target_city):
 
 def accommodation_type(activity, target_city):
     accommodations = _tools_for_lang(_infer_lang_from_city(target_city))["accommodations"]
+    position = normalize_poi_name(activity["position"])
     select_hotel_type = accommodations.select(
-        target_city, key="name", func=lambda x: x == activity["position"]
+        target_city, key="name", func=lambda x: x == position
     )["featurehoteltype"]
     if not select_hotel_type.empty:
         return normalize_concept_value("accommodation", select_hotel_type.iloc[0])

--- a/chinatravel/symbol_verification/hard_constraint.py
+++ b/chinatravel/symbol_verification/hard_constraint.py
@@ -13,6 +13,7 @@ from chinatravel.environment.language import CITY_NAMES, normalize_lang
 from chinatravel.symbol_verification.concept_func import (
     func_dict,
     normalize_concept_constraint_source,
+    normalize_poi_name,
     set_concept_func_lang,
 )
 from chinatravel.evaluation.utils import load_json_file
@@ -246,6 +247,7 @@ def get_symbolic_concepts(symbolic_input, plan_json, need_ood=False):
 
             if not "position" in activity:
                 continue
+            position = normalize_poi_name(activity["position"])
 
             if (
                 activity["type"] == "breakfast"
@@ -253,11 +255,11 @@ def get_symbolic_concepts(symbolic_input, plan_json, need_ood=False):
                 or activity["type"] == "dinner"
             ):
                 select_food_type = restaurants.select(
-                    target_city, key="name", func=lambda x: x == activity["position"]
+                    target_city, key="name", func=lambda x: x == position
                 )["cuisine"]
                 if not select_food_type.empty:
                     food_type.add(select_food_type.iloc[0])
-                restaurant_names.add(activity["position"])
+                restaurant_names.add(position)
 
                 if "cost" in activity:
                     food_prices.append(activity["cost"])
@@ -267,11 +269,11 @@ def get_symbolic_concepts(symbolic_input, plan_json, need_ood=False):
 
             if activity["type"] == "accommodation":
                 select_hotel_type = accommodation.select(
-                    target_city, key="name", func=lambda x: x == activity["position"]
+                    target_city, key="name", func=lambda x: x == position
                 )["featurehoteltype"]
                 if not select_hotel_type.empty:
                     hotel_feature.add(select_hotel_type.iloc[0])
-                hotel_names.add(activity["position"])
+                hotel_names.add(position)
 
                 if "cost" in activity:
                     hotel_prices.append(activity["cost"])
@@ -287,7 +289,7 @@ def get_symbolic_concepts(symbolic_input, plan_json, need_ood=False):
 
             if activity["type"] == "attraction":
                 select_attraction_type = attractions.select(
-                    target_city, key="name", func=lambda x: x == activity["position"]
+                    target_city, key="name", func=lambda x: x == position
                 )["type"]
                 if not select_attraction_type.empty:
                     spot_type.add(select_attraction_type.iloc[0])
@@ -298,7 +300,7 @@ def get_symbolic_concepts(symbolic_input, plan_json, need_ood=False):
                     # print(ood_attractions_dataframe.loc[ood_attractions_dataframe['name'] == activity["position"]])
 
                     attraction_sel = ood_attractions_dataframe.loc[
-                        ood_attractions_dataframe["name"] == activity["position"]
+                        ood_attractions_dataframe["name"] == position
                     ]
                     if len(attraction_sel) > 0:
                         attraction_info = attraction_sel.iloc[0]
@@ -306,7 +308,7 @@ def get_symbolic_concepts(symbolic_input, plan_json, need_ood=False):
                         for ood_type in ood_type_dict:
                             if attraction_info[ood_type] == 1:
                                 spot_type.add(ood_type_dict[ood_type])
-                attraction_names.add(activity["position"])
+                attraction_names.add(position)
 
                 if "cost" in activity:
                     total_cost += activity.get("cost", 0)

--- a/eval_tpc.py
+++ b/eval_tpc.py
@@ -226,7 +226,7 @@ if __name__ == "__main__":
         scores['ATT']=pre_res[1]*100
         scores['DDR']=pre_res[2]*100
 
-        final_score=0.1*micro_comm+0.1*micro_comm+0.25*conditional_micro_logi+0.05*scores['DAV']+0.05*scores['ATT']+0.05*scores['DDR']+0.4*fpr
+        final_score=0.1*micro_comm+0.1*macro_comm+0.25*conditional_micro_logi+0.05*scores['DAV']+0.05*scores['ATT']+0.05*scores['DDR']+0.4*fpr
         print('Overall Score: ',final_score)
         scores['overall'] = final_score
         print(scores)


### PR DESCRIPTION
## Summary

This PR tightens evaluator grounding for itinerary activities so intercity transport entries cannot be used as unchecked POI-like activities.

Changes:
- Add a global activity grounding commonsense check.
- Reject mid-itinerary `airplane` / `train` activities and reject intercity activities that provide a POI `position`.
- Require regular POI activities to provide `position` and disallow intercity-only fields such as `start`, `end`, `FlightID`, and `TrainID` on those activities.
- Make `activity_position()` return an empty string for intercity transport activities.
- Tighten the output schema to reflect the same separation between intercity and POI activities.
- Fix the overall score formula to use `MacEPR` instead of counting `MicEPR` twice.

## Root Cause

Some DSL constraints call `activity_position(activity)` without checking activity type. Previously, a submitted plan could place a train or airplane in the middle of the itinerary, attach a POI-like `position`, and satisfy position-based hard logic while bypassing POI validation and intercity transport validation.

## Validation

- `python -m py_compile chinatravel/symbol_verification/commonsense_constraint.py chinatravel/evaluation/commonsense_constraint.py chinatravel/symbol_verification/concept_func.py eval_tpc.py`
- `python -m json.tool chinatravel/evaluation/output_schema.json`

The updated checks also reject constructed plans where a middle intercity transport attempts to act as a POI activity.