### PR TITLE
Fix evaluator chronology and daily meal limits

### DIFF
--- a/chinatravel/symbol_verification/commonsense_constraint.py
+++ b/chinatravel/symbol_verification/commonsense_constraint.py
@@ -674,34 +674,43 @@ def Is_hotels_correct(symbolic_input, plan_json, verbose=False):
 def Is_restaurants_correct(symbolic_input, plan_json, verbose=False): 
     
     target_city = symbolic_input["target_city"]
-    table_statistics = pd.DataFrame(columns=['Unavailable Restruants', 'Visiting Restruants in their closed time', 'Repeated Restruants Choices', 'Incorrect price Information of Restruants', 'Incorrect cost Information of Restruants', 'Inappropriate Meal Times'])
+    table_statistics = pd.DataFrame(columns=['Unavailable Restruants', 'Visiting Restruants in their closed time', 'Repeated Restruants Choices', 'Incorrect price Information of Restruants', 'Incorrect cost Information of Restruants', 'Inappropriate Meal Times', 'Repeated Meal Types in One Day'])
 
     error_info = []    
     try: 
         plan_json["itinerary"]
     except: 
-        table_statistics.loc[0] = [1, 1, 1, 1, 1, 1]
+        table_statistics.loc[0] = 1
         error_info = ["Error plan type, must be python dict"]
         return table_statistics, error_info
 
-    table_statistics.loc[0] = [0, 0, 0, 0, 0, 0]
+    table_statistics.loc[0] = 0
 
     plan = plan_json["itinerary"]
     
     restaurants_list = []
     restaurants_time_list = []
 
-    for day_plan_i in plan:
+    for day_idx, day_plan_i in enumerate(plan):
+        meal_counts = {"breakfast": 0, "lunch": 0, "dinner": 0}
         for activity_i in day_plan_i["activities"]:
             try: activity_i["type"]
             except: continue
             if not activity_i["type"] in ["breakfast", "lunch", "dinner"]:
                 continue
+
+            meal_type = activity_i["type"]
+            meal_counts[meal_type] += 1
+            if meal_counts[meal_type] > 1:
+                table_statistics.loc[0, 'Repeated Meal Types in One Day'] = 1
+                error_info.append(
+                    "Only one {} is allowed on day {}.".format(meal_type, day_idx + 1)
+                )
             
             # print(activity_i)
             try: activity_i["position"]
             except: 
-                table_statistics.loc[0] = [1, 1, 1, 1, 1, 1]
+                table_statistics.loc[0] = 1
                 error_info.append("No position information!")
                 return table_statistics, error_info
             
@@ -716,7 +725,7 @@ def Is_restaurants_correct(symbolic_input, plan_json, verbose=False):
                 select_hotel=accommodation.select(target_city,key='name',func=lambda x:x==position)
     
                 if select_hotel.empty:
-                    table_statistics.loc[0] = [1, 1, 1, 1, 1, 1]
+                    table_statistics.loc[0] = 1
                     error_info.append("No information found given restaurant [{}]".format(activity_i["position"]))
                 try:
                     activity_i["price"]
@@ -752,7 +761,7 @@ def Is_restaurants_correct(symbolic_input, plan_json, verbose=False):
             
             if select_restaurant.empty:
                 # return return_info(False, "No information found given restaurant [{}]".format(activity_i["position"]))
-                table_statistics.loc[0] = [1, 1, 1, 1, 1, 1]
+                table_statistics.loc[0] = 1
                 error_info.append("No information found given restaurant [{}]".format(activity_i["position"]))
                 continue
             
@@ -1067,8 +1076,9 @@ def Is_time_correct(symbolic_input, plan_json, verbose=False):
     table_statistics.loc[0] = [0, 0]
 
     plan = plan_json["itinerary"]
-    for day_plan_i in plan:
-        for activity_i in day_plan_i["activities"]:
+    for day_idx, day_plan_i in enumerate(plan):
+        previous_activity_end = None
+        for activity_idx, activity_i in enumerate(day_plan_i["activities"]):
             
             # print(activity_i)
             try: activity_i["start_time"] and activity_i["end_time"]
@@ -1076,28 +1086,43 @@ def Is_time_correct(symbolic_input, plan_json, verbose=False):
                 table_statistics.loc[0, 'Invalid duration information of each activity'] = 1
                 error_info = ["Activity should provide start_time and end_time"]
                 return table_statistics, error_info
-    
+
             activity_st_time = activity_i["start_time"]
             activity_ed_time = activity_i["end_time"]
+            activity_st_real = time2real(activity_st_time)
+            activity_ed_real = time2real(activity_ed_time)
 
-            if time2real(activity_st_time) >= time2real(activity_ed_time) and (not activity_i["type"] in ["train", "airplane"]): # 可能出现次日到达
+            if activity_st_real >= activity_ed_real and (not activity_i["type"] in ["train", "airplane"]): # 可能出现次日到达
                 table_statistics.loc[0, 'Does not follow Chronological Order'] = 1
                 error_info.append("Activities must cost time: " + str(activity_i))
-            
 
-            if not "transports" in activity_i:
-                continue
+            if previous_activity_end is not None and activity_st_real < previous_activity_end:
+                table_statistics.loc[0, 'Does not follow Chronological Order'] = 1
+                error_info.append(
+                    "Activities must not overlap on day {}, activity {}: {}".format(
+                        day_idx + 1, activity_idx + 1, activity_i
+                    )
+                )
 
-            if len(activity_i["transports"]) > 0:
+            if len(activity_i.get("transports", [])) > 0:
                 transport_st_time = activity_i["transports"][0]["start_time"]
                 transport_ed_time = activity_i["transports"][-1]["end_time"]
-            
-                if time2real(activity_st_time) < time2real(transport_ed_time):
+                transport_st_real = time2real(transport_st_time)
+                transport_ed_real = time2real(transport_ed_time)
 
+                if previous_activity_end is not None and transport_st_real < previous_activity_end:
+                    table_statistics.loc[0, 'Does not follow Chronological Order'] = 1
+                    error_info.append(
+                        "Transport must depart after the previous activity ends on day {}, activity {}: {}".format(
+                            day_idx + 1, activity_idx + 1, activity_i
+                        )
+                    )
+
+                if activity_st_real < transport_ed_real:
                     table_statistics.loc[0, 'Does not follow Chronological Order'] = 1
                     error_info.append("Must arrive at the location before starting the activity: " + str(activity_i))
 
-            
+            previous_activity_end = activity_ed_real
 
     if verbose:
         if table_statistics.loc[0].sum() == 0:

--- a/tests/test_evaluator_chronology_and_meals.py
+++ b/tests/test_evaluator_chronology_and_meals.py
@@ -1,0 +1,148 @@
+import unittest
+from unittest.mock import patch
+
+import pandas as pd
+
+from chinatravel.symbol_verification import commonsense_constraint as commonsense
+
+
+class _StaticSelector:
+    def __init__(self, rows):
+        self._frame = pd.DataFrame(rows)
+
+    def select(self, *args, **kwargs):
+        return self._frame.copy()
+
+
+def _activity(start_time, end_time, transports=None):
+    return {
+        "type": "attraction",
+        "start_time": start_time,
+        "end_time": end_time,
+        "transports": transports or [],
+    }
+
+
+def _hotel_breakfast(start_time, end_time):
+    return {
+        "type": "breakfast",
+        "position": "Test Hotel",
+        "price": 0,
+        "cost": 0,
+        "start_time": start_time,
+        "end_time": end_time,
+        "transports": [],
+    }
+
+
+class TimeValidationTests(unittest.TestCase):
+    def test_overlapping_activities_are_rejected(self):
+        plan = {
+            "itinerary": [
+                {
+                    "activities": [
+                        _activity("09:00", "11:00"),
+                        _activity("10:00", "12:00"),
+                    ]
+                }
+            ]
+        }
+
+        table, errors = commonsense.Is_time_correct({"target_city": "南京"}, plan)
+
+        self.assertEqual(table.loc[0, "Does not follow Chronological Order"], 1)
+        self.assertTrue(any("must not overlap" in error for error in errors))
+
+    def test_transport_cannot_depart_before_previous_activity_ends(self):
+        inbound_transport = [
+            {
+                "start_time": "09:30",
+                "end_time": "10:30",
+            }
+        ]
+        plan = {
+            "itinerary": [
+                {
+                    "activities": [
+                        _activity("09:00", "10:00"),
+                        _activity("10:30", "11:30", inbound_transport),
+                    ]
+                }
+            ]
+        }
+
+        table, errors = commonsense.Is_time_correct({"target_city": "南京"}, plan)
+
+        self.assertEqual(table.loc[0, "Does not follow Chronological Order"], 1)
+        self.assertTrue(any("Transport must depart" in error for error in errors))
+
+    def test_ordered_activity_and_transport_are_accepted(self):
+        inbound_transport = [
+            {
+                "start_time": "10:00",
+                "end_time": "10:30",
+            }
+        ]
+        plan = {
+            "itinerary": [
+                {
+                    "activities": [
+                        _activity("09:00", "10:00"),
+                        _activity("10:30", "11:30", inbound_transport),
+                    ]
+                }
+            ]
+        }
+
+        table, errors = commonsense.Is_time_correct({"target_city": "南京"}, plan)
+
+        self.assertEqual(table.loc[0].sum(), 0)
+        self.assertEqual(errors, [])
+
+
+class MealValidationTests(unittest.TestCase):
+    def setUp(self):
+        self.symbolic_input = {"target_city": "南京", "people_number": 1}
+        self.restaurant_selector = _StaticSelector([])
+        self.hotel_selector = _StaticSelector([{"name": "Test Hotel"}])
+
+    def _evaluate(self, plan):
+        with (
+            patch.object(commonsense, "restaurants", self.restaurant_selector),
+            patch.object(commonsense, "accommodation", self.hotel_selector),
+        ):
+            return commonsense.Is_restaurants_correct(self.symbolic_input, plan)
+
+    def test_one_hotel_breakfast_per_day_is_accepted(self):
+        plan = {
+            "itinerary": [
+                {"activities": [_hotel_breakfast("06:30", "07:30")]},
+                {"activities": [_hotel_breakfast("07:00", "08:00")]},
+            ]
+        }
+
+        table, errors = self._evaluate(plan)
+
+        self.assertEqual(table.loc[0].sum(), 0)
+        self.assertEqual(errors, [])
+
+    def test_multiple_hotel_breakfasts_on_one_day_are_rejected(self):
+        plan = {
+            "itinerary": [
+                {
+                    "activities": [
+                        _hotel_breakfast("06:30", "07:00"),
+                        _hotel_breakfast("07:00", "07:30"),
+                    ]
+                }
+            ]
+        }
+
+        table, errors = self._evaluate(plan)
+
+        self.assertEqual(table.loc[0, "Repeated Meal Types in One Day"], 1)
+        self.assertTrue(any("Only one breakfast" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- reject overlapping or out-of-order activities within each itinerary day
- require inbound transport to depart after the previous activity ends and arrive before the current activity starts
- allow at most one breakfast, lunch, and dinner per day while preserving one free hotel breakfast per day
- add focused regression coverage for valid and invalid chronology and hotel-breakfast cases

## Root cause

The time verifier validated activities and inbound transports only in isolation, without retaining the preceding activity's end time. Hotel breakfasts also bypassed restaurant uniqueness without a separate per-day meal-type limit.

## Validation

- `python -m unittest tests.test_evaluator_chronology_and_meals -v`: 5 tests passed in both runnable evaluator copies
- syntax compilation passed against this public-code checkout
- full Phase 1 English regression completed in the automatic evaluator

Ticket, vehicle, room-count, preference, and scoring rules are intentionally unchanged in this PR.