### PR TITLE
Fix evaluator scoring, grounding, and split loading

### DIFF
--- a/chinatravel/data/load_datasets.py
+++ b/chinatravel/data/load_datasets.py
@@ -26,6 +26,68 @@ class NpEncoder(json.JSONEncoder):
         return super(NpEncoder, self).default(obj)
 
 
+def _resolve_local_query_paths(data_dir, split, query_ids, lang):
+    preferred_names = [split]
+    if lang == "en" and not split.endswith("_EN"):
+        preferred_names.append(f"{split}_EN")
+    preferred_dirs = [
+        os.path.join(data_dir, name)
+        for name in preferred_names
+        if os.path.isdir(os.path.join(data_dir, name))
+    ]
+    for split_dir in preferred_dirs:
+        paths = {
+            query_id: os.path.join(split_dir, f"{query_id}.json")
+            for query_id in query_ids
+        }
+        if all(os.path.isfile(path) for path in paths.values()):
+            return paths
+    if preferred_dirs:
+        missing = {
+            split_dir: [
+                query_id
+                for query_id in query_ids
+                if not os.path.isfile(
+                    os.path.join(split_dir, f"{query_id}.json")
+                )
+            ]
+            for split_dir in preferred_dirs
+        }
+        raise ValueError(
+            f"Split directory does not contain every configured UID: {missing}"
+        )
+
+    indexed_paths = {query_id: [] for query_id in query_ids}
+    for directory_name in sorted(os.listdir(data_dir)):
+        directory = os.path.join(data_dir, directory_name)
+        if not os.path.isdir(directory):
+            continue
+        for query_id in query_ids:
+            path = os.path.join(directory, f"{query_id}.json")
+            if os.path.isfile(path):
+                indexed_paths[query_id].append(path)
+
+    missing = [
+        query_id for query_id, paths in indexed_paths.items() if not paths
+    ]
+    ambiguous = {
+        query_id: paths
+        for query_id, paths in indexed_paths.items()
+        if len(paths) > 1
+    }
+    if missing or ambiguous:
+        raise ValueError(
+            "Unable to resolve local split {!r}: missing={}, ambiguous={}".format(
+                split,
+                missing,
+                ambiguous,
+            )
+        )
+    return {
+        query_id: paths[0] for query_id, paths in indexed_paths.items()
+    }
+
+
 def load_query_local(args, version="", verbose=False):
     query_data = {}
     lang = normalize_lang(getattr(args, "lang", None))
@@ -55,28 +117,28 @@ def load_query_local(args, version="", verbose=False):
     if lang == "en":
         data_dir = os.path.join(data_dir, "en")
 
-    dir_list = os.listdir(data_dir)
-    for dir_i in dir_list:
-        dir_ii = os.path.join(data_dir, dir_i)
-        if os.path.isdir(dir_ii):
-            file_list = os.listdir(dir_ii)
-
-            for file_i in file_list:
-                query_id = file_i.split(".")[0]
-                if query_id in query_id_list:
-                    data_i = json.load(
-                        open(os.path.join(dir_ii, file_i), encoding="utf-8")
-                    )
-
-                    if hasattr(args, 'oracle_translation') and not args.oracle_translation:
-                        if "hard_logic" in data_i:
-                            del data_i["hard_logic"]
-                        if "hard_logic_py" in data_i:
-                            del data_i["hard_logic_py"]
-                        if "hard_logic_nl" in data_i:
-                            del data_i["hard_logic_nl"]
-
-                    query_data[query_id] = data_i
+    query_paths = _resolve_local_query_paths(
+        data_dir,
+        args.splits,
+        query_id_list,
+        lang,
+    )
+    for query_id in query_id_list:
+        with open(query_paths[query_id], encoding="utf-8") as query_file:
+            data_i = json.load(query_file)
+        if data_i.get("uid") != query_id:
+            raise ValueError(
+                f"Query UID mismatch for {query_paths[query_id]}: "
+                f"expected {query_id!r}, got {data_i.get('uid')!r}"
+            )
+        if hasattr(args, 'oracle_translation') and not args.oracle_translation:
+            if "hard_logic" in data_i:
+                del data_i["hard_logic"]
+            if "hard_logic_py" in data_i:
+                del data_i["hard_logic_py"]
+            if "hard_logic_nl" in data_i:
+                del data_i["hard_logic_nl"]
+        query_data[query_id] = data_i
 
     # print(query_data)
 
@@ -164,4 +226,3 @@ if __name__ == "__main__":
             print(uid, query_data[uid])
         else:
             raise ValueError(f"{uid} not in query_data")
-

--- a/chinatravel/evaluation/commonsense_constraint.py
+++ b/chinatravel/evaluation/commonsense_constraint.py
@@ -71,12 +71,12 @@ def evaluate_commonsense_constraints(data_index, symbolic_input_dict, plan_json_
 
 
         symbolic_input, plan_json = symbolic_input_dict[idx], plan_json_dict[idx]
-        _set_tool_lang(lang or _infer_lang(symbolic_input))
         
         if verbose:
             print(symbolic_input)
             print(plan_json)
         try:
+            _set_tool_lang(lang or _infer_lang(symbolic_input))
             for func in func_list:
 
                 table_res, error_info = func(symbolic_input, plan_json, verbose=verbose)
@@ -95,10 +95,14 @@ def evaluate_commonsense_constraints(data_index, symbolic_input_dict, plan_json_
                 individual_succ += 1
                 pass_id.append(idx)
         except Exception as message:
-            pass
-            # print("Error: ", message)
-            # print(symbolic_input)
-            # print(plan_json)
+            error_column = 'Commonsense Evaluator Exception'
+            if error_column not in result_agg.columns:
+                result_agg[error_column] = 0
+            result_agg.loc[ii, error_column] = 1
+            print(
+                "Commonsense evaluation failed for {}: {}".format(idx, message),
+                file=sys.stderr,
+            )
         
                             
 

--- a/chinatravel/symbol_verification/commonsense_constraint.py
+++ b/chinatravel/symbol_verification/commonsense_constraint.py
@@ -1191,6 +1191,12 @@ def Is_space_correct(symbolic_input, plan_json, verbose=False):
                         table_statistics.loc[0, 'Invalid Transport information across positions'] = 1
                         error_info.append("The destination of the transport must be equal to the position of the current activity.: " + str(activity_i))
                         # continue
+            elif (len(position_list) > 0) and activity_i.get("transports"):
+                table_statistics.loc[0, 'Invalid Transport information across positions'] = 1
+                error_info.append(
+                    "Transport must be empty between activities at the same position: "
+                    + str(activity_i)
+                )
 
             if "position" in activity_i:
                 position_list.append(normalize_poi_name(activity_i["position"]))

--- a/eval_tpc.py
+++ b/eval_tpc.py
@@ -41,8 +41,11 @@ for activity in allactivities(plan):
     if transports!=[]:
         transport_count += 1
         time_cost += innercity_transport_time(transports)
-average_time_cost = time_cost / transport_count if transport_count > 0 else -1
-result= (-1/105) * average_time_cost + 8/7
+if transport_count > 0:
+    average_time_cost = time_cost / transport_count
+    result= (-1/105) * average_time_cost + 8/7
+else:
+    result=0
 """
 DEFAULT_RES_PR="""
 res_count=0
@@ -81,6 +84,7 @@ def cal_default_pr_score(query_index, query_data, result_data,all_pass_id):
         results = []
         if idx not in all_pass_id:
             results=np.zeros(len(DEFAULT_PR))
+            all_score.append(results)
             continue
         for constraint in DEFAULT_PR:
             vars_dict = deepcopy(func_dict)

--- a/tests/test_evaluator_scoring_and_grounding.py
+++ b/tests/test_evaluator_scoring_and_grounding.py
@@ -1,0 +1,181 @@
+import contextlib
+import io
+import unittest
+from contextlib import ExitStack
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+import eval_tpc
+from chinatravel.evaluation import commonsense_constraint as evaluation
+from chinatravel.symbol_verification import commonsense_constraint as commonsense
+
+
+def _preference_plan():
+    activities = [
+        {"type": "attraction", "transports": []}
+        for _ in range(4)
+    ]
+    activities.extend(
+        {"type": meal_type, "transports": []}
+        for meal_type in ("breakfast", "lunch", "dinner")
+    )
+    return {
+        "people_number": 1,
+        "start_city": "北京",
+        "target_city": "南京",
+        "itinerary": [{"day": 1, "activities": activities}],
+    }
+
+
+class DefaultPreferenceScoringTests(unittest.TestCase):
+    def test_no_innercity_transport_receives_zero_att(self):
+        plan = _preference_plan()
+
+        scores = eval_tpc.cal_default_pr_score(
+            ["valid"],
+            {"valid": {}},
+            {"valid": plan},
+            ["valid"],
+        )
+
+        np.testing.assert_allclose(scores, np.array([1.0, 0.0, 1.0]))
+
+    def test_invalid_samples_contribute_zero_to_preference_average(self):
+        plan = _preference_plan()
+
+        scores = eval_tpc.cal_default_pr_score(
+            ["valid", "invalid"],
+            {"valid": {}, "invalid": {}},
+            {"valid": plan, "invalid": plan},
+            ["valid"],
+        )
+
+        np.testing.assert_allclose(scores, np.array([0.5, 0.0, 0.5]))
+
+
+class CommonsenseExceptionTests(unittest.TestCase):
+    def test_validator_exception_is_recorded_as_failure(self):
+        zero_result = pd.DataFrame({"Mock Validation": [0]})
+        validator_names = (
+            "Is_activity_grounded",
+            "Is_intercity_transport_correct",
+            "Is_attractions_correct",
+            "Is_hotels_correct",
+            "Is_restaurants_correct",
+            "Is_transport_correct",
+            "Is_time_correct",
+            "Is_space_correct",
+        )
+
+        with ExitStack() as stack:
+            stack.enter_context(patch.object(evaluation, "_set_tool_lang"))
+            for name in validator_names:
+                stack.enter_context(
+                    patch.object(
+                        evaluation,
+                        name,
+                        return_value=(zero_result, []),
+                    )
+                )
+            stack.enter_context(
+                patch.object(
+                    evaluation,
+                    "Is_time_correct",
+                    side_effect=RuntimeError("test failure"),
+                )
+            )
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                _, _, result_agg, pass_ids = (
+                    evaluation.evaluate_commonsense_constraints(
+                        ["query-id"],
+                        {
+                            "query-id": {
+                                "start_city": "北京",
+                                "target_city": "南京",
+                            }
+                        },
+                        {"query-id": {"itinerary": []}},
+                        lang="zh",
+                    )
+                )
+
+        self.assertEqual(
+            result_agg.loc[0, "Commonsense Evaluator Exception"],
+            1,
+        )
+        self.assertEqual(pass_ids, [])
+        self.assertIn("query-id", stderr.getvalue())
+        self.assertIn("test failure", stderr.getvalue())
+
+
+class SamePositionTransportTests(unittest.TestCase):
+    def test_unrelated_transport_at_same_position_is_rejected(self):
+        plan = {
+            "itinerary": [
+                {
+                    "activities": [
+                        {
+                            "type": "attraction",
+                            "position": "Same Place",
+                            "transports": [],
+                        },
+                        {
+                            "type": "attraction",
+                            "position": "Same Place",
+                            "transports": [
+                                {
+                                    "start": "Other Place A",
+                                    "end": "Other Place B",
+                                }
+                            ],
+                        },
+                    ]
+                }
+            ]
+        }
+
+        table, errors = commonsense.Is_space_correct(
+            {"target_city": "南京"},
+            plan,
+        )
+
+        self.assertEqual(
+            table.loc[0, "Invalid Transport information across positions"],
+            1,
+        )
+        self.assertTrue(any("same position" in error for error in errors))
+
+    def test_empty_transport_at_same_position_is_accepted(self):
+        plan = {
+            "itinerary": [
+                {
+                    "activities": [
+                        {
+                            "type": "attraction",
+                            "position": "Same Place",
+                            "transports": [],
+                        },
+                        {
+                            "type": "attraction",
+                            "position": "Same Place",
+                            "transports": [],
+                        },
+                    ]
+                }
+            ]
+        }
+
+        table, errors = commonsense.Is_space_correct(
+            {"target_city": "南京"},
+            plan,
+        )
+
+        self.assertEqual(table.loc[0].sum(), 0)
+        self.assertEqual(errors, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_query_loader_resolution.py
+++ b/tests/test_query_loader_resolution.py
@@ -1,0 +1,79 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from chinatravel.data import load_datasets
+
+
+def write_query(path, uid, marker):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                "uid": uid,
+                "hard_logic_py": [],
+                "nature_language": marker,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class LocalQueryResolutionTests(unittest.TestCase):
+    def make_root(self, temp_name, split, uids):
+        root = Path(temp_name)
+        split_file = (
+            root
+            / "chinatravel"
+            / "evaluation"
+            / "default_splits"
+            / f"{split}.txt"
+        )
+        split_file.parent.mkdir(parents=True, exist_ok=True)
+        split_file.write_text("\n".join(uids) + "\n", encoding="utf-8")
+        return root
+
+    def test_named_english_split_cannot_be_shadowed_by_other_directories(self):
+        with tempfile.TemporaryDirectory() as temp_name:
+            root = self.make_root(temp_name, "phase", ["uid-1"])
+            data_root = root / "chinatravel" / "data" / "en"
+            write_query(data_root / "phase_EN" / "uid-1.json", "uid-1", "official")
+            write_query(data_root / "other" / "uid-1.json", "uid-1", "shadow")
+            args = SimpleNamespace(splits="phase", lang="en")
+
+            with patch.object(load_datasets, "project_root_path", str(root)):
+                query_ids, records = load_datasets.load_query_local(args)
+
+            self.assertEqual(query_ids, ["uid-1"])
+            self.assertEqual(records["uid-1"]["nature_language"], "official")
+
+    def test_fallback_resolution_rejects_duplicate_uids(self):
+        with tempfile.TemporaryDirectory() as temp_name:
+            root = self.make_root(temp_name, "combined", ["uid-1"])
+            data_root = root / "chinatravel" / "data" / "en"
+            write_query(data_root / "first" / "uid-1.json", "uid-1", "first")
+            write_query(data_root / "second" / "uid-1.json", "uid-1", "second")
+            args = SimpleNamespace(splits="combined", lang="en")
+
+            with patch.object(load_datasets, "project_root_path", str(root)):
+                with self.assertRaisesRegex(ValueError, "ambiguous"):
+                    load_datasets.load_query_local(args)
+
+    def test_incomplete_named_split_fails_instead_of_mixing_directories(self):
+        with tempfile.TemporaryDirectory() as temp_name:
+            root = self.make_root(temp_name, "phase", ["uid-1", "uid-2"])
+            data_root = root / "chinatravel" / "data" / "en"
+            write_query(data_root / "phase_EN" / "uid-1.json", "uid-1", "official")
+            write_query(data_root / "other" / "uid-2.json", "uid-2", "shadow")
+            args = SimpleNamespace(splits="phase", lang="en")
+
+            with patch.object(load_datasets, "project_root_path", str(root)):
+                with self.assertRaisesRegex(ValueError, "every configured UID"):
+                    load_datasets.load_query_local(args)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Count schema/commonsense/hard-logic-invalid samples as zero in DAV, ATT, and DDR instead of dropping them from the preference average.
- Return ATT = 0 when a valid plan contains no inner-city transport.
- Record commonsense validator exceptions as explicit failures rather than silently ignoring them.
- Reject unrelated transport records inserted between consecutive activities at the same position.
- Load local query data from the directory owned by the requested split and reject ambiguous duplicate UID resolution.

## Validation

- `python -m unittest tests.test_evaluator_scoring_and_grounding tests.test_query_loader_resolution -v`
- 8 tests passed.
- Phase 2 seed-plan regression: 2000/2000 full records and 100/100 familiar records passed schema, commonsense, and hard-logic checks.

This PR is independent of #29 and is based directly on `main`; the two PRs can be reviewed and merged separately.