### PR TITLE
Synchronize evaluator normalization and performance fixes

### DIFF
--- a/chinatravel/environment/concept_labels.py
+++ b/chinatravel/environment/concept_labels.py
@@ -1,0 +1,54 @@
+"""Canonical labels for concept-valued fields exposed by the sandbox."""
+
+from chinatravel.environment.language import normalize_lang
+
+
+ENGLISH_CONCEPT_VALUE_ALIASES = {
+    "attraction": {
+        "Art Museum": "Art museum",
+        "Cultural Attractions": "Cultural Landscape",
+        "Historical Site": "historical site",
+        "Natural Scenery": "natural scenery",
+        "Park": "park",
+        "red tourism sites": "Red tourism sites",
+        "university campus": "University campus",
+    },
+    "restaurant": {
+        "Bread and Desserts": "Bakery and Desserts",
+        "cafe": "coffee shop",
+        "Fast food and simple meals": "Fast food and casual dining",
+        "hot pot": "Hot pot",
+    },
+    "accommodation": {
+        "Air Purifier": "Air purifier",
+        "Bed and Breakfast": "homestay",
+        "Bed and breakfast": "homestay",
+        "Designer Hotel": "Designer hotel",
+        "Family Theme Room": "Family-themed room",
+        "Family-themed Room": "Family-themed room",
+        "Great View from the Window": "Great view from the window",
+        "Scenic Window View": "Great view from the window",
+        "Instagrammable swimming pool": "Instagrammable pool",
+        "Chess and Card Room": "Mahjong and Card Game Room",
+        "Mahjong and Card Room": "Mahjong and Card Game Room",
+        "Serviced Apartment": "Hotel Apartment",
+        "small but beautiful": "small and beautiful",
+        "SPA": "Spa",
+        "Stunning night views": "Stunning Night Views",
+        "Swimming pool": "Swimming Pool",
+        "viral swimming pool": "Instagrammable pool",
+    },
+}
+
+ENGLISH_CONCEPT_LITERAL_ALIASES = {
+    alias: canonical
+    for aliases in ENGLISH_CONCEPT_VALUE_ALIASES.values()
+    for alias, canonical in aliases.items()
+}
+
+
+def normalize_concept_value(kind, value, lang="en"):
+    if normalize_lang(lang) != "en" or not isinstance(value, str):
+        return value
+    stripped = value.strip()
+    return ENGLISH_CONCEPT_VALUE_ALIASES.get(kind, {}).get(stripped, stripped)

--- a/chinatravel/environment/tools/accommodations/apis.py
+++ b/chinatravel/environment/tools/accommodations/apis.py
@@ -8,6 +8,7 @@ import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from poi.apis import Poi
+from chinatravel.environment.concept_labels import normalize_concept_value
 from chinatravel.environment.language import CITY_SLUGS, city_names, normalize_lang, relative_database_path
 
 
@@ -26,6 +27,14 @@ class Accommodations:
         self.data = {}
         for i, city in enumerate(city_list):
             self.data[city] = pd.read_csv(data_path_list[i]).dropna()
+            if self.lang == "en":
+                self.data[city]["featurehoteltype"] = self.data[city][
+                    "featurehoteltype"
+                ].map(
+                    lambda value: normalize_concept_value(
+                        "accommodation", value, self.lang
+                    )
+                )
         self.key_type_tuple_list = {}
         for city in city_list:
             self.key_type_tuple_list[city] = []

--- a/chinatravel/environment/tools/attractions/apis.py
+++ b/chinatravel/environment/tools/attractions/apis.py
@@ -8,6 +8,7 @@ import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from poi.apis import Poi
+from chinatravel.environment.concept_labels import normalize_concept_value
 from chinatravel.environment.language import CITY_SLUGS, city_names, normalize_lang, relative_database_path
 
 
@@ -31,6 +32,12 @@ class Attractions:
         self.data = {}
         for i, city in enumerate(city_list):
             self.data[city] = pd.read_csv(data_path_list[i])
+            if self.lang == "en":
+                self.data[city]["type"] = self.data[city]["type"].map(
+                    lambda value: normalize_concept_value(
+                        "attraction", value, self.lang
+                    )
+                )
         self.key_type_tuple_list_map = {}
         for city in city_list:
             self.key_type_tuple_list_map[city] = []

--- a/chinatravel/environment/tools/poi/apis.py
+++ b/chinatravel/environment/tools/poi/apis.py
@@ -16,7 +16,8 @@ class Poi:
         ]
         self.data = {}
         for i, city in enumerate(city_list):
-            self.data[city] = json.load(open(data_path_list[i], "r", encoding="utf-8"))
+            with open(data_path_list[i], "r", encoding="utf-8") as file:
+                self.data[city] = json.load(file)
             city_data = {}
             for name_pos in self.data[city]:
                 name = name_pos["name"]

--- a/chinatravel/environment/tools/restaurants/apis.py
+++ b/chinatravel/environment/tools/restaurants/apis.py
@@ -8,6 +8,7 @@ import sys
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from poi.apis import Poi
+from chinatravel.environment.concept_labels import normalize_concept_value
 from chinatravel.environment.language import CITY_SLUGS, city_names, normalize_lang, relative_database_path
 
 
@@ -22,6 +23,12 @@ class Restaurants:
         for city in city_list:
             path = os.path.join(curdir, base_path, city, "restaurants_" + city + ".csv")
             self.data[city] = pd.read_csv(path)
+            if self.lang == "en":
+                self.data[city]["cuisine"] = self.data[city]["cuisine"].map(
+                    lambda value: normalize_concept_value(
+                        "restaurant", value, self.lang
+                    )
+                )
 
         self.key_type_tuple_list_map = {}
         for city in city_list:

--- a/chinatravel/environment/tools/transportation/apis.py
+++ b/chinatravel/environment/tools/transportation/apis.py
@@ -2,6 +2,7 @@ import os
 import json
 import heapq
 from geopy.distance import geodesic
+from geographiclib.geodesic import Geodesic
 
 from chinatravel.environment.tools.poi.apis import Poi
 from chinatravel.environment.language import CITY_SLUGS, city_names, normalize_lang, relative_database_path
@@ -96,8 +97,19 @@ def find_shortest_path(graph, start, end):
 def find_nearest_station(location, stations):
     nearest_station = None
     min_distance = float("inf")
+    latitude, longitude = location
+    inverse = Geodesic.WGS84.Inverse
     for station in stations:
-        distance = geodesic(location, station["position"]).kilometers
+        station_latitude, station_longitude = station["position"]
+        distance = (
+            inverse(
+                latitude,
+                longitude,
+                station_latitude,
+                station_longitude,
+            )["s12"]
+            / 1000.0
+        )
         if distance < min_distance:
             min_distance = distance
             nearest_station = station
@@ -164,6 +176,16 @@ class Transportation:
             self.graphs[city] = build_graph(self.city_lines_dict[city])
 
         self.poi_search = Poi(lang=self.lang)
+        self._nearest_station_cache = {}
+
+    def _find_nearest_station(self, city, location_name, location):
+        cache_key = (city, location_name)
+        if cache_key not in self._nearest_station_cache:
+            self._nearest_station_cache[cache_key] = find_nearest_station(
+                location,
+                self.city_stations_dict[city],
+            )
+        return self._nearest_station_cache[cache_key]
 
     def goto(self, city, start, end, start_time, transport_type, verbose=False):
         if transport_type not in ["walk", "metro", "taxi"]:
@@ -230,11 +252,15 @@ class Transportation:
 
         elif transport_type == "metro":
             graph = self.graphs[city]
-            stationA, distanceA = find_nearest_station(
-                locationA, self.city_stations_dict[city]
+            stationA, distanceA = self._find_nearest_station(
+                city,
+                locationA_name,
+                locationA,
             )
-            stationB, distanceB = find_nearest_station(
-                locationB, self.city_stations_dict[city]
+            stationB, distanceB = self._find_nearest_station(
+                city,
+                locationB_name,
+                locationB,
             )
             if stationA == stationB:
                 if verbose:

--- a/chinatravel/evaluation/schema_constraint.py
+++ b/chinatravel/evaluation/schema_constraint.py
@@ -19,6 +19,7 @@ import pandas as pd
 import json
 import jsonschema
 from jsonschema import validate
+from jsonschema.validators import validator_for
 
 def validate_json(json_data, schema):
     try:
@@ -34,6 +35,9 @@ def evaluate_schema_constraints(data_index, plan_json_dict, schema):
     total_correct = 0
     result_agg = pd.DataFrame(columns=['data_id', "schema"])
     result_agg['data_id'] = data_index
+    validator_class = validator_for(schema)
+    validator_class.check_schema(schema)
+    validator = validator_class(schema)
 
     pass_id = []
 
@@ -44,7 +48,7 @@ def evaluate_schema_constraints(data_index, plan_json_dict, schema):
 
         succ_flag = 0
         try:        
-            if validate_json(plan_json, schema):
+            if validator.is_valid(plan_json):
                 succ_flag = 1
                 pass_id.append(idx)
         except:
@@ -114,4 +118,3 @@ if __name__ == "__main__":
     # for item in info_list:
     #     print(item)
     # print(info_list)
-

--- a/chinatravel/symbol_verification/concept_func.py
+++ b/chinatravel/symbol_verification/concept_func.py
@@ -1,52 +1,15 @@
 from chinatravel.environment.tools.accommodations.apis import Accommodations
 from chinatravel.environment.tools.restaurants.apis import Restaurants
 from chinatravel.environment.tools.attractions.apis import Attractions
+from chinatravel.environment.concept_labels import (
+    ENGLISH_CONCEPT_LITERAL_ALIASES,
+    normalize_concept_value as normalize_sandbox_concept_value,
+)
 from chinatravel.environment.language import CITY_NAMES, normalize_lang
 
 
 _current_lang = "zh"
 _TOOLS_BY_LANG = {}
-_CONCEPT_VALUE_ALIASES = {
-    "attraction": {
-        "Art Museum": "Art museum",
-        "Cultural Attractions": "Cultural Landscape",
-        "Historical Site": "historical site",
-        "Natural Scenery": "natural scenery",
-        "Park": "park",
-        "red tourism sites": "Red tourism sites",
-        "university campus": "University campus",
-    },
-    "restaurant": {
-        "Bread and Desserts": "Bakery and Desserts",
-        "cafe": "coffee shop",
-        "Fast food and simple meals": "Fast food and casual dining",
-        "hot pot": "Hot pot",
-    },
-    "accommodation": {
-        "Air Purifier": "Air purifier",
-        "Bed and Breakfast": "homestay",
-        "Bed and breakfast": "homestay",
-        "Designer Hotel": "Designer hotel",
-        "Family Theme Room": "Family-themed room",
-        "Family-themed Room": "Family-themed room",
-        "Great View from the Window": "Great view from the window",
-        "Scenic Window View": "Great view from the window",
-        "Instagrammable swimming pool": "Instagrammable pool",
-        "Chess and Card Room": "Mahjong and Card Game Room",
-        "Mahjong and Card Room": "Mahjong and Card Game Room",
-        "Serviced Apartment": "Hotel Apartment",
-        "small but beautiful": "small and beautiful",
-        "SPA": "Spa",
-        "Stunning night views": "Stunning Night Views",
-        "Swimming pool": "Swimming Pool",
-        "viral swimming pool": "Instagrammable pool",
-    },
-}
-_CONCEPT_LITERAL_ALIASES = {
-    alias: canonical
-    for aliases in _CONCEPT_VALUE_ALIASES.values()
-    for alias, canonical in aliases.items()
-}
 _POI_NAME_ALIASES = {
     "Bistro Sola": "Sola Bistro",
 }
@@ -75,9 +38,7 @@ def set_concept_func_lang(lang=None):
 
 
 def normalize_concept_value(kind, value):
-    if not isinstance(value, str):
-        return value
-    return _CONCEPT_VALUE_ALIASES.get(kind, {}).get(value, value)
+    return normalize_sandbox_concept_value(kind, value, _current_lang)
 
 
 def normalize_poi_name(value):
@@ -90,7 +51,9 @@ def normalize_concept_constraint_source(source):
     if not isinstance(source, str):
         return source
     normalized = source
-    for alias, canonical in {**_CONCEPT_LITERAL_ALIASES, **_POI_NAME_ALIASES}.items():
+    aliases = dict(ENGLISH_CONCEPT_LITERAL_ALIASES)
+    aliases.update(_POI_NAME_ALIASES)
+    for alias, canonical in aliases.items():
         for quote in ("'", '"'):
             normalized = normalized.replace(
                 f"{quote}{alias}{quote}", f"{quote}{canonical}{quote}"
@@ -206,7 +169,8 @@ def innercity_transport_cost(transports, node=None):
     """
     cost = 0
     for transport in transports:
-        if node is None or transport.get("type") == node:
+        transport_mode = transport.get("mode", transport.get("type"))
+        if node is None or transport_mode == node:
             cost += transport.get("cost", 0)
     return cost
 
@@ -229,7 +193,8 @@ def innercity_transport_distance(transports, mode=None):
     """
     distance = 0
     for transport in transports:
-        if mode is None or transport.get("type") == mode:
+        transport_mode = transport.get("mode", transport.get("type"))
+        if mode is None or transport_mode == mode:
             distance += transport.get("distance", 0)
     return distance
 
@@ -244,7 +209,11 @@ def innercity_transport_time(transports, mode=None):
 
     time_cost = 0
     for transport in transports:
-        time_cost += calc_time_delta(transport["end_time"], transport["start_time"])
+        transport_mode = transport.get("mode", transport.get("type"))
+        if mode is None or transport_mode == mode:
+            time_cost += calc_time_delta(
+                transport["end_time"], transport["start_time"]
+            )
     return time_cost
 
 def metro_tickets(transports):

--- a/tests/test_concept_normalization_and_transport_helpers.py
+++ b/tests/test_concept_normalization_and_transport_helpers.py
@@ -1,0 +1,107 @@
+import unittest
+
+from chinatravel.environment.concept_labels import (
+    ENGLISH_CONCEPT_VALUE_ALIASES,
+    normalize_concept_value as normalize_sandbox_concept_value,
+)
+from chinatravel.environment.tools.accommodations.apis import Accommodations
+from chinatravel.environment.tools.attractions.apis import Attractions
+from chinatravel.environment.tools.restaurants.apis import Restaurants
+from chinatravel.symbol_verification.concept_func import (
+    innercity_transport_cost,
+    innercity_transport_distance,
+    innercity_transport_time,
+    normalize_concept_constraint_source,
+    normalize_concept_value,
+    set_concept_func_lang,
+)
+
+
+class ConceptNormalizationTests(unittest.TestCase):
+    def tearDown(self):
+        set_concept_func_lang("zh")
+
+    def test_symbolic_and_sandbox_normalization_share_aliases(self):
+        set_concept_func_lang("en")
+
+        self.assertEqual(normalize_concept_value("restaurant", "cafe"), "coffee shop")
+        self.assertEqual(
+            normalize_sandbox_concept_value(
+                "attraction", "university campus", "en"
+            ),
+            "University campus",
+        )
+        self.assertEqual(
+            normalize_sandbox_concept_value("accommodation", "Swimming pool", "zh"),
+            "Swimming pool",
+        )
+
+    def test_constraint_literals_use_the_shared_alias_dictionary(self):
+        source = (
+            'result=({"cafe", "university campus", "Swimming pool"} '
+            "<= concept_values)"
+        )
+        normalized = normalize_concept_constraint_source(source)
+
+        self.assertIn('"coffee shop"', normalized)
+        self.assertIn('"University campus"', normalized)
+        self.assertIn('"Swimming Pool"', normalized)
+
+    def test_english_environment_exposes_only_canonical_values(self):
+        cases = (
+            (Attractions(lang="en"), "type", "attraction"),
+            (Restaurants(lang="en"), "cuisine", "restaurant"),
+            (Accommodations(lang="en"), "featurehoteltype", "accommodation"),
+        )
+
+        for tool, column, kind in cases:
+            aliases = ENGLISH_CONCEPT_VALUE_ALIASES[kind]
+            with self.subTest(kind=kind):
+                for table in tool.data.values():
+                    values = set(table[column].dropna())
+                    self.assertTrue(values.isdisjoint(aliases))
+                    self.assertEqual(
+                        values,
+                        {
+                            normalize_sandbox_concept_value(kind, value, "en")
+                            for value in values
+                        },
+                    )
+
+
+class InnerCityTransportHelperTests(unittest.TestCase):
+    def test_mode_filters_support_current_and_legacy_transport_fields(self):
+        transports = [
+            {
+                "mode": "walk",
+                "cost": 1,
+                "distance": 1.5,
+                "start_time": "08:00",
+                "end_time": "08:10",
+            },
+            {
+                "type": "walk",
+                "cost": 2,
+                "distance": 2.5,
+                "start_time": "08:10",
+                "end_time": "08:15",
+            },
+            {
+                "mode": "taxi",
+                "cost": 9,
+                "distance": 8,
+                "start_time": "08:15",
+                "end_time": "08:30",
+            },
+        ]
+
+        self.assertEqual(innercity_transport_cost(transports, "walk"), 3)
+        self.assertEqual(innercity_transport_distance(transports, "walk"), 4)
+        self.assertEqual(innercity_transport_time(transports, "walk"), 15)
+        self.assertEqual(innercity_transport_cost(transports), 12)
+        self.assertEqual(innercity_transport_distance(transports), 12)
+        self.assertEqual(innercity_transport_time(transports), 30)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evaluator_performance_caches.py
+++ b/tests/test_evaluator_performance_caches.py
@@ -1,0 +1,99 @@
+import unittest
+from unittest.mock import patch
+
+from geopy.distance import geodesic
+
+from chinatravel.environment.tools.transportation import apis
+from chinatravel.evaluation import schema_constraint
+
+
+class TransportationCacheTests(unittest.TestCase):
+    def test_nearest_station_matches_geopy_wgs84(self):
+        location = (30.7762, 114.2081)
+        stations = [
+            {"name": "A", "position": (30.7781, 114.2110)},
+            {"name": "B", "position": (30.7810, 114.2012)},
+        ]
+        expected_station = min(
+            stations,
+            key=lambda station: geodesic(
+                location,
+                station["position"],
+            ).kilometers,
+        )
+        station, distance = apis.find_nearest_station(
+            location,
+            stations,
+        )
+
+        self.assertEqual(station, expected_station)
+        self.assertAlmostEqual(
+            distance,
+            geodesic(location, station["position"]).kilometers,
+            places=12,
+        )
+
+    def test_nearest_metro_station_is_cached_per_poi(self):
+        transportation = apis.Transportation.__new__(apis.Transportation)
+        transportation._nearest_station_cache = {}
+        transportation.city_stations_dict = {
+            "wuhan": [
+                {"name": "A", "position": (30.7781, 114.2110)},
+                {"name": "B", "position": (30.7810, 114.2012)},
+            ]
+        }
+        original = apis.find_nearest_station
+
+        with patch.object(
+            apis,
+            "find_nearest_station",
+            wraps=original,
+        ) as find_nearest:
+            first = transportation._find_nearest_station(
+                "wuhan",
+                "Wuhan Tianhe International Airport",
+                (30.7762, 114.2081),
+            )
+            second = transportation._find_nearest_station(
+                "wuhan",
+                "Wuhan Tianhe International Airport",
+                (30.7762, 114.2081),
+            )
+
+        self.assertEqual(find_nearest.call_count, 1)
+        self.assertEqual(first, second)
+
+
+class SchemaValidatorReuseTests(unittest.TestCase):
+    def test_schema_is_compiled_once_per_batch(self):
+        schema = {
+            "type": "object",
+            "required": ["value"],
+            "properties": {"value": {"type": "integer"}},
+        }
+        records = {
+            "valid": {"value": 1},
+            "invalid": {"value": "not-an-integer"},
+        }
+        original = schema_constraint.validator_for
+
+        with patch.object(
+            schema_constraint,
+            "validator_for",
+            wraps=original,
+        ) as get_validator:
+            rate, _, pass_ids = (
+                schema_constraint.evaluate_schema_constraints(
+                    ["valid", "invalid"],
+                    records,
+                    schema,
+                )
+            )
+
+        self.assertEqual(get_validator.call_count, 1)
+        self.assertEqual(rate, 50.0)
+        self.assertEqual(pass_ids, ["valid"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- canonicalize English concept labels from one shared mapping and normalize sandbox database values at load time
- make inner-city cost, distance, and time helpers accept the current `mode` field while retaining the legacy `type` fallback
- reuse compiled JSON Schema validators and cache nearest-metro-station lookups
- close POI database files deterministically
- add focused regression tests for concept aliases, transport helper filtering, schema reuse, and station caching

## Validation

- `python -m compileall -q chinatravel tests`
- `python -m unittest discover -s tests -v` (20 tests passed)
- patch path and content scans found no synthetic query generation code, Phase 2 data, archives, translation artifacts, or credentials

This PR contains only evaluator/runtime fixes and tests. It does not include `synthetic_query_generation` or generated competition data.