### PR TITLE
Fix English language propagation in agent harness

### DIFF
--- a/agent_env/README.md
+++ b/agent_env/README.md
@@ -35,8 +35,11 @@ return initialization errors until the official prerequisites are present.
 Configure the agent client to run:
 
 ```bash
-python -m agent_env.mcp_stdio
+CHINATRAVEL_LANG=en python -m agent_env.mcp_stdio
 ```
+
+`CHINATRAVEL_LANG` selects both the query language and sandbox database. It accepts
+`en` or `zh`.
 
 The server exposes tools such as:
 
@@ -57,25 +60,25 @@ advanced query needs the original `WorldEnv` command-string surface.
 List available tools:
 
 ```bash
-python -m agent_env.cli tools
+python -m agent_env.cli --lang en tools
 ```
 
 Call a structured tool:
 
 ```bash
-python -m agent_env.cli call attractions_keys '{"city":"上海"}'
+python -m agent_env.cli --lang en call attractions_keys '{"city":"Shanghai"}'
 ```
 
 Call the original command-string interface:
 
 ```bash
-python -m agent_env.cli world "attractions_keys('上海')"
+python -m agent_env.cli --lang en world "attractions_keys('Shanghai')"
 ```
 
 Start an interactive prompt:
 
 ```bash
-python -m agent_env.cli
+python -m agent_env.cli --lang en
 ```
 
 Inside the prompt:
@@ -96,9 +99,12 @@ Create a local config from the tracked example:
 cp agent_env/config.toml.example agent_env/config.toml
 ```
 
-Edit `agent_env/config.toml` to set the split, harness, smoke-test limit,
+Edit `agent_env/config.toml` to set the split, language, harness, smoke-test limit,
 models, providers, and API key or API key env var. The local config is ignored
 by git because it may contain a secret.
+
+Keep `lang = "en"` for the English competition data. This setting is applied to
+query loading, environment tools, and both commonsense and hard-logic evaluation.
 
 Run the configured harness non-interactively over the configured split and
 evaluate each output:
@@ -116,7 +122,7 @@ python agent_env/scripts/solve_script_with_harness.py
 Use a specific query or override the configured model from the CLI:
 
 ```bash
-python agent_env/scripts/solve_script_with_harness.py --uid <uid>
+python agent_env/scripts/solve_script_with_harness.py --lang en --uid <uid>
 python agent_env/scripts/solve_script_with_harness.py --harness opencode --model dashscope/qwen3.6-27b
 python agent_env/scripts/solve_script_with_harness.py --harness codex --model gpt-5.5
 python agent_env/scripts/solve_script_with_harness.py --resume
@@ -148,7 +154,7 @@ JSONL events, and extract final text into `output.txt`; Codex runs use
 Start the local server:
 
 ```bash
-python -m agent_env.http_server --host 127.0.0.1 --port 8765
+python -m agent_env.http_server --lang en --host 127.0.0.1 --port 8765
 ```
 
 List tools:
@@ -162,7 +168,7 @@ Call a tool:
 ```bash
 curl -X POST http://127.0.0.1:8765/call \
   -H 'Content-Type: application/json' \
-  -d '{"tool":"attractions_keys","arguments":{"city":"上海"}}'
+  -d '{"tool":"attractions_keys","arguments":{"city":"Shanghai"}}'
 ```
 
 Call the original command-string interface:
@@ -170,7 +176,7 @@ Call the original command-string interface:
 ```bash
 curl -X POST http://127.0.0.1:8765/world-command \
   -H 'Content-Type: application/json' \
-  -d '{"command":"attractions_keys(\"上海\")"}'
+  -d '{"command":"attractions_keys(\"Shanghai\")"}'
 ```
 
 ## Boundary

--- a/agent_env/SKILL.md
+++ b/agent_env/SKILL.md
@@ -16,10 +16,10 @@ structured tool catalog does not cover the lookup.
 Run commands from the repository root:
 
 ```bash
-python -m agent_env.cli tools
-python -m agent_env.cli splits
-python -m agent_env.cli call <tool_name> '<json_arguments>'
-python -m agent_env.cli world "<WorldEnv command>"
+python -m agent_env.cli --lang en tools
+python -m agent_env.cli --lang en splits
+python -m agent_env.cli --lang en call <tool_name> '<json_arguments>'
+python -m agent_env.cli --lang en world "<WorldEnv command>"
 ```
 
 The CLI returns JSON. Check `success` before relying on `data`.
@@ -29,45 +29,45 @@ The CLI returns JSON. Check `success` before relying on `data`.
 List query splits:
 
 ```bash
-python -m agent_env.cli call china_travel_list_splits
+python -m agent_env.cli --lang en call china_travel_list_splits
 ```
 
 Load query metadata:
 
 ```bash
-python -m agent_env.cli call china_travel_load_query '{"split":"easy"}'
-python -m agent_env.cli call china_travel_load_query '{"split":"easy","uid":"<uid>"}'
+python -m agent_env.cli --lang en call china_travel_load_query '{"split":"easy"}'
+python -m agent_env.cli --lang en call china_travel_load_query '{"split":"easy","uid":"<uid>"}'
 ```
 
 Inspect available columns:
 
 ```bash
-python -m agent_env.cli call attractions_keys '{"city":"上海"}'
-python -m agent_env.cli call restaurants_keys '{"city":"上海"}'
-python -m agent_env.cli call accommodations_keys '{"city":"上海"}'
+python -m agent_env.cli --lang en call attractions_keys '{"city":"Shanghai"}'
+python -m agent_env.cli --lang en call restaurants_keys '{"city":"Shanghai"}'
+python -m agent_env.cli --lang en call accommodations_keys '{"city":"Shanghai"}'
 ```
 
 Filter resources:
 
 ```bash
-python -m agent_env.cli call attractions_select '{"city":"上海","key":"name","op":"contains","value":"博物馆"}'
-python -m agent_env.cli call restaurants_select '{"city":"上海","key":"cuisine","op":"eq","value":"本帮江浙菜"}'
-python -m agent_env.cli call accommodations_select '{"city":"上海","key":"price","op":"le","value":500}'
+python -m agent_env.cli --lang en call attractions_select '{"city":"Shanghai","key":"name","op":"contains","value":"Museum"}'
+python -m agent_env.cli --lang en call restaurants_select '{"city":"Shanghai","key":"cuisine","op":"contains","value":"Chinese"}'
+python -m agent_env.cli --lang en call accommodations_select '{"city":"Shanghai","key":"price","op":"le","value":500}'
 ```
 
 Find nearby resources:
 
 ```bash
-python -m agent_env.cli call attractions_nearby '{"city":"上海","point":"上海迪士尼度假区","topk":5,"dist":5}'
-python -m agent_env.cli call restaurants_nearby '{"city":"上海","point":"上海迪士尼度假区","topk":5,"dist":2}'
-python -m agent_env.cli call accommodations_nearby '{"city":"上海","point":"上海迪士尼度假区","topk":5,"dist":5}'
+python -m agent_env.cli --lang en call attractions_nearby '{"city":"Shanghai","point":"Shanghai Disneyland","topk":5,"dist":5}'
+python -m agent_env.cli --lang en call restaurants_nearby '{"city":"Shanghai","point":"Shanghai Disneyland","topk":5,"dist":2}'
+python -m agent_env.cli --lang en call accommodations_nearby '{"city":"Shanghai","point":"Shanghai Disneyland","topk":5,"dist":5}'
 ```
 
 Check transport:
 
 ```bash
-python -m agent_env.cli call intercity_transport_select '{"start_city":"北京","end_city":"上海","intercity_type":"train","earliest_leave_time":"07:00"}'
-python -m agent_env.cli call goto '{"city":"上海","start":"上海站","end":"上海迪士尼度假区","start_time":"09:00","transport_type":"metro"}'
+python -m agent_env.cli --lang en call intercity_transport_select '{"start_city":"Beijing","end_city":"Shanghai","intercity_type":"train","earliest_leave_time":"07:00"}'
+python -m agent_env.cli --lang en call goto '{"city":"Shanghai","start":"Shanghai Railway Station","end":"Shanghai Disneyland","start_time":"09:00","transport_type":"metro"}'
 ```
 
 Use the exact values returned by the tools for prices, IDs, names, times,
@@ -102,18 +102,18 @@ Use the bundled harness to load a configured split, call a harness non-interacti
 save plans under `results/<method>/<uid>.json`, and evaluate them:
 
 ```bash
-python agent_env/scripts/solve_script_with_harness.py --split easy
+python agent_env/scripts/solve_script_with_harness.py --lang en --split easy
 ```
 
 Useful options:
 
 ```bash
-python agent_env/scripts/solve_script_with_harness.py --split easy --uid <uid>
-python agent_env/scripts/solve_script_with_harness.py --split easy --harness opencode --model dashscope/qwen3.6-27b
-python agent_env/scripts/solve_script_with_harness.py --split easy --harness codex --model gpt-5.5
-python agent_env/scripts/solve_script_with_harness.py --split easy --timeout 900
-python agent_env/scripts/solve_script_with_harness.py --split easy --limit 1
-python agent_env/scripts/solve_script_with_harness.py --split easy --no-run-harness
+python agent_env/scripts/solve_script_with_harness.py --lang en --split easy --uid <uid>
+python agent_env/scripts/solve_script_with_harness.py --lang en --split easy --harness opencode --model dashscope/qwen3.6-27b
+python agent_env/scripts/solve_script_with_harness.py --lang en --split easy --harness codex --model gpt-5.5
+python agent_env/scripts/solve_script_with_harness.py --lang en --split easy --timeout 900
+python agent_env/scripts/solve_script_with_harness.py --lang en --split easy --limit 1
+python agent_env/scripts/solve_script_with_harness.py --lang en --split easy --no-run-harness
 ```
 
 The harness hides oracle verifier fields from the selected model, but keeps them

--- a/agent_env/adapter.py
+++ b/agent_env/adapter.py
@@ -20,6 +20,13 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_PAGE_SIZE = 10
 
 
+def _normalize_adapter_lang(lang: str | None = None) -> str:
+    value = str(lang or os.environ.get("CHINATRAVEL_LANG") or "zh").lower()
+    if value not in {"zh", "en"}:
+        raise ValueError("ChinaTravel language must be 'zh' or 'en'.")
+    return value
+
+
 def _ensure_project_on_path() -> None:
     root = str(PROJECT_ROOT)
     if root not in sys.path:
@@ -104,7 +111,12 @@ def _schema(required: list[str], properties: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-CITY = {"type": "string", "description": "Chinese city name, e.g. 上海, 北京"}
+CITY = {
+    "type": "string",
+    "description": (
+        "City name in the selected sandbox language, e.g. Shanghai for en or 上海 for zh"
+    ),
+}
 POINT = {"type": "string", "description": "POI name; must match ChinaTravel data"}
 TIME = {"type": "string", "description": "HH:MM"}
 TOPK = {"type": "integer", "default": 10, "minimum": 1}
@@ -289,7 +301,8 @@ TOOL_SPECS: dict[str, ToolSpec] = {
 
 
 class ChinaTravelEnvAdapter:
-    def __init__(self) -> None:
+    def __init__(self, lang: str | None = None) -> None:
+        self.lang = _normalize_adapter_lang(lang)
         self._env: Any | None = None
 
     def list_tools(self) -> list[dict[str, Any]]:
@@ -357,7 +370,11 @@ class ChinaTravelEnvAdapter:
             _ensure_project_on_path()
             from chinatravel.data.load_datasets import load_query
 
-            args = argparse.Namespace(splits=split, oracle_translation=oracle_translation)
+            args = argparse.Namespace(
+                splits=split,
+                oracle_translation=oracle_translation,
+                lang=self.lang,
+            )
             query_ids, query_data = load_query(args)
             if uid is not None:
                 if uid not in query_data:
@@ -382,7 +399,7 @@ class ChinaTravelEnvAdapter:
             _ensure_project_on_path()
             from chinatravel.environment.world_env import WorldEnv
 
-            self._env = WorldEnv()
+            self._env = WorldEnv(lang=self.lang)
         return self._env
 
     def _env_output_to_dict(self, output: Any, *, command: str) -> dict[str, Any]:
@@ -403,4 +420,3 @@ class ChinaTravelEnvAdapter:
 
 def dumps_result(result: dict[str, Any]) -> str:
     return json.dumps(result, ensure_ascii=False, indent=2)
-

--- a/agent_env/cli.py
+++ b/agent_env/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 from typing import Any
 
@@ -97,6 +98,12 @@ def run_repl(adapter: ChinaTravelEnvAdapter) -> int:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Call ChinaTravel agent environment tools.")
+    parser.add_argument(
+        "--lang",
+        choices=["zh", "en"],
+        default=os.environ.get("CHINATRAVEL_LANG", "zh"),
+        help="Sandbox/query language. Defaults to CHINATRAVEL_LANG or zh.",
+    )
     subparsers = parser.add_subparsers(dest="command")
 
     subparsers.add_parser("tools", help="List available tools.")
@@ -116,7 +123,7 @@ def main() -> None:
     world_parser.add_argument("world_command", help="WorldEnv command string.")
 
     args = parser.parse_args()
-    adapter = ChinaTravelEnvAdapter()
+    adapter = ChinaTravelEnvAdapter(lang=args.lang)
 
     try:
         if args.command is None or args.command == "repl":

--- a/agent_env/config.toml.example
+++ b/agent_env/config.toml.example
@@ -1,5 +1,6 @@
 [run]
 split = "easy"
+lang = "en"
 harness = "opencode"
 method = ""
 work_dir = ""

--- a/agent_env/http_server.py
+++ b/agent_env/http_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
@@ -55,11 +56,18 @@ class Handler(BaseHTTPRequestHandler):
 
 
 def main() -> None:
+    global ADAPTER
     parser = argparse.ArgumentParser(description="Run ChinaTravel agent HTTP environment.")
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument(
+        "--lang",
+        choices=["zh", "en"],
+        default=os.environ.get("CHINATRAVEL_LANG", "zh"),
+    )
     args = parser.parse_args()
 
+    ADAPTER = ChinaTravelEnvAdapter(lang=args.lang)
     server = ThreadingHTTPServer((args.host, args.port), Handler)
     print(f"ChinaTravel agent HTTP env listening on http://{args.host}:{args.port}", flush=True)
     server.serve_forever()
@@ -67,4 +75,3 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
-

--- a/agent_env/scripts/solve_script_with_harness.py
+++ b/agent_env/scripts/solve_script_with_harness.py
@@ -27,18 +27,27 @@ def default_tool_python() -> str:
     return "uv run python"
 
 
-def load_queries(split: str) -> tuple[list[str], dict[str, Any]]:
+def normalize_lang(lang: Any) -> str:
+    value = str(lang).lower()
+    if value not in {"zh", "en"}:
+        raise ValueError("ChinaTravel language must be 'zh' or 'en'.")
+    return value
+
+
+def load_queries(split: str, lang: str) -> tuple[list[str], dict[str, Any]]:
     from chinatravel.data.load_datasets import load_query
 
-    args = argparse.Namespace(splits=split, oracle_translation=True)
+    args = argparse.Namespace(splits=split, oracle_translation=True, lang=lang)
     query_ids, query_data = load_query(args)
     if not query_ids:
         raise RuntimeError(f"No queries found for split: {split}")
     return query_ids, query_data
 
 
-def load_one_query(split: str, uid: str | None) -> tuple[str, dict[str, Any]]:
-    query_ids, query_data = load_queries(split)
+def load_one_query(
+    split: str, uid: str | None, lang: str = "en"
+) -> tuple[str, dict[str, Any]]:
+    query_ids, query_data = load_queries(split, lang)
     query_uid = uid or query_ids[0]
     if query_uid not in query_data:
         raise RuntimeError(f"Query uid {query_uid!r} not found in split {split!r}")
@@ -141,8 +150,15 @@ def load_plan_from_output_txt(
     )
 
 
-def build_prompt(split: str, uid: str, query: dict[str, Any], tool_python: str) -> str:
+def build_prompt(
+    split: str,
+    uid: str,
+    query: dict[str, Any],
+    tool_python: str,
+    lang: str,
+) -> str:
     query_text = json.dumps(query, ensure_ascii=False, indent=2)
+    cli_python = f"{tool_python} -m agent_env.cli --lang {lang}"
     return f"""You are solving one ChinaTravel benchmark query.
 
 Work quietly. Do not narrate your plan, progress, or calculations. Use CLI calls only
@@ -158,12 +174,12 @@ Run CLI commands from that repository root using this Python command:
 Use this command for every `agent_env.cli` call. Do not use bare `python`.
 
 Important commands:
-- {tool_python} -m agent_env.cli tools
-- {tool_python} -m agent_env.cli call attractions_keys '{{"city":"<target_city>"}}'
-- {tool_python} -m agent_env.cli call restaurants_keys '{{"city":"<target_city>"}}'
-- {tool_python} -m agent_env.cli call accommodations_keys '{{"city":"<target_city>"}}'
-- {tool_python} -m agent_env.cli call intercity_transport_select '{{"start_city":"<start_city>","end_city":"<target_city>","intercity_type":"train","earliest_leave_time":"07:00"}}'
-- {tool_python} -m agent_env.cli call goto '{{"city":"<target_city>","start":"<exact start>","end":"<exact end>","start_time":"HH:MM","transport_type":"metro"}}'
+- {cli_python} tools
+- {cli_python} call attractions_keys '{{"city":"<target_city>"}}'
+- {cli_python} call restaurants_keys '{{"city":"<target_city>"}}'
+- {cli_python} call accommodations_keys '{{"city":"<target_city>"}}'
+- {cli_python} call intercity_transport_select '{{"start_city":"<start_city>","end_city":"<target_city>","intercity_type":"train","earliest_leave_time":"07:00"}}'
+- {cli_python} call goto '{{"city":"<target_city>","start":"<exact start>","end":"<exact end>","start_time":"HH:MM","transport_type":"metro"}}'
 
 Use exact names, prices, costs, times, distances, TrainID/FlightID values, and transport
 segments returned by the CLI. Do not invent environment facts.
@@ -436,7 +452,11 @@ def run_codex(
 
 
 def evaluate_one(
-    split: str, uid: str, query: dict[str, Any], plan: dict[str, Any]
+    split: str,
+    uid: str,
+    query: dict[str, Any],
+    plan: dict[str, Any],
+    lang: str,
 ) -> dict[str, Any]:
     from chinatravel.evaluation.commonsense_constraint import (
         evaluate_commonsense_constraints,
@@ -457,7 +477,7 @@ def evaluate_one(
     )
     macro_comm, micro_comm, common_result_agg, commonsense_pass_id = (
         evaluate_commonsense_constraints(
-            query_index, query_data, result_data, verbose=False
+            query_index, query_data, result_data, verbose=False, lang=lang
         )
     )
     (
@@ -473,6 +493,7 @@ def evaluate_one(
         result_data,
         env_pass_id=commonsense_pass_id,
         verbose=False,
+        lang=lang,
     )
 
     return {
@@ -501,6 +522,7 @@ def evaluate_split(
     method: str,
     query_ids: list[str],
     query_data: dict[str, Any],
+    lang: str,
     parse_failure_ids: list[str] | None = None,
 ) -> dict[str, Any]:
     from chinatravel.evaluation.commonsense_constraint import (
@@ -532,7 +554,7 @@ def evaluate_split(
         )
         macro_comm, micro_comm, common_result_agg, commonsense_pass_id = (
             evaluate_commonsense_constraints(
-                evaluated_ids, query_data, result_data, verbose=False
+                evaluated_ids, query_data, result_data, verbose=False, lang=lang
             )
         )
         (
@@ -548,6 +570,7 @@ def evaluate_split(
             result_data,
             env_pass_id=commonsense_pass_id,
             verbose=False,
+            lang=lang,
         )
         schema_details = schema_result_agg.to_dict(orient="records")
         commonsense_details = common_result_agg.to_dict(orient="records")
@@ -670,6 +693,7 @@ def solve_query(
     *,
     harness: str,
     split: str,
+    lang: str,
     uid: str,
     query: dict[str, Any],
     method: str,
@@ -691,7 +715,7 @@ def solve_query(
     eval_path = run_dir / "evaluation.json"
     result_path = PROJECT_ROOT / "results" / method / f"{uid}.json"
 
-    prompt = build_prompt(split, uid, public_query, tool_python)
+    prompt = build_prompt(split, uid, public_query, tool_python, lang)
     run_dir.mkdir(parents=True, exist_ok=True)
     prompt_path.write_text(prompt, encoding="utf-8")
 
@@ -765,7 +789,7 @@ def solve_query(
     write_json(result_path, plan)
     print(f"Saved plan: {result_path}")
 
-    evaluation = evaluate_one(split, uid, query, plan)
+    evaluation = evaluate_one(split, uid, query, plan, lang)
     write_json(eval_path, evaluation)
     print(f"Saved evaluation: {eval_path}")
     print(json.dumps(evaluation, ensure_ascii=False, indent=2, default=json_default))
@@ -781,6 +805,12 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--split", default=None, help="ChinaTravel split name. Overrides [run].split."
+    )
+    parser.add_argument(
+        "--lang",
+        choices=["zh", "en"],
+        default=None,
+        help="Query and sandbox language. Overrides [run].lang.",
     )
     parser.add_argument(
         "--uid", default=None, help="Optional query UID. Overrides [run].uid."
@@ -895,6 +925,7 @@ def main() -> None:
     codex_config = config_section(config, "codex")
 
     split = str(choose(args.split, run_config.get("split"), "easy"))
+    lang = normalize_lang(choose(args.lang, run_config.get("lang"), "en"))
     uid = choose(args.uid, run_config.get("uid"), None)
     limit = choose(args.limit, run_config.get("limit"), None)
     if harness == "opencode":
@@ -942,7 +973,7 @@ def main() -> None:
         )
     )
 
-    query_ids, query_data = load_queries(split)
+    query_ids, query_data = load_queries(split, lang)
     if uid:
         uid = str(uid)
         if uid not in query_data:
@@ -957,7 +988,7 @@ def main() -> None:
 
     print(f"Config: {Path(args.config)}")
     print(
-        f"Run: split={split} queries={len(selected_ids)} harness={harness} method={method} "
+        f"Run: split={split} lang={lang} queries={len(selected_ids)} harness={harness} method={method} "
         f"model={model or '<config default>'} resume={resume}"
     )
 
@@ -973,6 +1004,7 @@ def main() -> None:
         evaluation = solve_query(
             harness=harness,
             split=split,
+            lang=lang,
             uid=uid,
             query=query_data[uid],
             method=method,
@@ -999,7 +1031,12 @@ def main() -> None:
     if (evaluations or skipped_completed) and not args.uid:
         summary_path = PROJECT_ROOT / work_dir / f"{split}_summary.json"
         summary = evaluate_split(
-            split, method, selected_ids, query_data, parse_failure_ids=parse_failure_ids
+            split,
+            method,
+            selected_ids,
+            query_data,
+            lang,
+            parse_failure_ids=parse_failure_ids,
         )
         summary["skipped_completed"] = skipped_completed
         write_json(summary_path, summary)

--- a/tests/test_agent_env_language.py
+++ b/tests/test_agent_env_language.py
@@ -1,0 +1,122 @@
+import argparse
+import os
+import sys
+import types
+import unittest
+from unittest.mock import Mock, patch
+
+from agent_env.adapter import ChinaTravelEnvAdapter
+from agent_env.scripts.solve_script_with_harness import (
+    build_prompt,
+    evaluate_one,
+    normalize_lang,
+    visible_query,
+)
+
+
+class _Rows:
+    def to_dict(self, orient):
+        if orient != "records":
+            raise ValueError(f"Unexpected orient: {orient}")
+        return []
+
+
+class AgentEnvironmentLanguageTests(unittest.TestCase):
+    def test_adapter_uses_explicit_language_for_world_environment(self):
+        adapter = ChinaTravelEnvAdapter(lang="en")
+        world_env = Mock()
+        module = types.ModuleType("chinatravel.environment.world_env")
+        module.WorldEnv = world_env
+
+        with patch.dict(sys.modules, {module.__name__: module}):
+            adapter._get_env()
+
+        world_env.assert_called_once_with(lang="en")
+
+    def test_adapter_uses_environment_language(self):
+        with patch.dict(os.environ, {"CHINATRAVEL_LANG": "en"}):
+            adapter = ChinaTravelEnvAdapter()
+
+        self.assertEqual(adapter.lang, "en")
+
+    def test_load_query_receives_adapter_language(self):
+        adapter = ChinaTravelEnvAdapter(lang="en")
+        load_query = Mock(return_value=([], {}))
+        module = types.ModuleType("chinatravel.data.load_datasets")
+        module.load_query = load_query
+
+        with patch.dict(sys.modules, {module.__name__: module}):
+            result = adapter.load_query("easy")
+
+        self.assertTrue(result["success"])
+        args = load_query.call_args.args[0]
+        self.assertIsInstance(args, argparse.Namespace)
+        self.assertEqual(args.lang, "en")
+
+    def test_harness_prompt_uses_matching_cli_language(self):
+        prompt = build_prompt(
+            "phase1",
+            "sample-uid",
+            {"uid": "sample-uid", "query": "Plan a trip."},
+            "python",
+            "en",
+        )
+
+        self.assertIn("python -m agent_env.cli --lang en tools", prompt)
+        self.assertIn("--lang en call attractions_keys", prompt)
+
+    def test_oracle_fields_are_hidden_from_harness(self):
+        public = visible_query(
+            {
+                "uid": "sample-uid",
+                "query": "Plan a trip.",
+                "hard_logic": ["secret"],
+                "hard_logic_py": ["secret"],
+                "hard_logic_nl": ["secret"],
+            }
+        )
+
+        self.assertEqual(public, {"uid": "sample-uid", "query": "Plan a trip."})
+
+    def test_evaluator_receives_harness_language(self):
+        uid = "sample-uid"
+        schema_evaluator = Mock(return_value=(1.0, _Rows(), [uid]))
+        commonsense_evaluator = Mock(return_value=(1.0, 1.0, _Rows(), [uid]))
+        hard_evaluator = Mock(
+            return_value=(1.0, 1.0, 1.0, 1.0, _Rows(), [uid])
+        )
+        modules = {}
+        for name in (
+            "chinatravel.evaluation.schema_constraint",
+            "chinatravel.evaluation.commonsense_constraint",
+            "chinatravel.evaluation.hard_constraint",
+            "chinatravel.evaluation.utils",
+        ):
+            modules[name] = types.ModuleType(name)
+        modules[
+            "chinatravel.evaluation.schema_constraint"
+        ].evaluate_schema_constraints = schema_evaluator
+        modules[
+            "chinatravel.evaluation.commonsense_constraint"
+        ].evaluate_commonsense_constraints = commonsense_evaluator
+        modules[
+            "chinatravel.evaluation.hard_constraint"
+        ].evaluate_hard_constraints_v2 = hard_evaluator
+        modules["chinatravel.evaluation.utils"].load_json_file = Mock(return_value={})
+
+        with patch.dict(sys.modules, modules):
+            result = evaluate_one("phase1", uid, {"uid": uid}, {}, "en")
+
+        self.assertTrue(result["all_pass"])
+        self.assertEqual(commonsense_evaluator.call_args.kwargs["lang"], "en")
+        self.assertEqual(hard_evaluator.call_args.kwargs["lang"], "en")
+
+    def test_invalid_language_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "must be 'zh' or 'en'"):
+            ChinaTravelEnvAdapter(lang="english")
+        with self.assertRaisesRegex(ValueError, "must be 'zh' or 'en'"):
+            normalize_lang("english")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- propagate `lang` through local query loading, WorldEnv tools, prompts, and evaluator calls
- default the split harness example to English while retaining explicit Chinese support
- document English CLI, MCP, HTTP, and harness usage
- add regression tests for language propagation and oracle-field hiding

## Verification
- `27/27` unit tests pass with the official Chinese and English databases
- real English sandbox call: `python -m agent_env.cli --lang en call attractions_keys '{"city":"Shanghai"}'`

This PR contains only public harness code, documentation, and tests. It does not include generated data or generation logic.